### PR TITLE
olimex-teres-a64: Use edge kernel due to mesa regression

### DIFF
--- a/targets/default.conf
+++ b/targets/default.conf
@@ -237,11 +237,11 @@ lime-a64                  current         jammy       desktop                  s
 
 
 # Olimex Teres A64
-olimex-teres-a64          current         bullseye    cli	               stable,nightly         yes
-olimex-teres-a64          current         jammy       cli                      stable         adv
-olimex-teres-a64          current         bookworm    desktop                  stable         adv	     gnome	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-olimex-teres-a64          current         bullseye    desktop                  stable         yes	     cinnamon	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-olimex-teres-a64          current         bullseye    desktop                  stable         yes	     xfce	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+olimex-teres-a64          edge         bullseye    cli	               stable,nightly         yes
+olimex-teres-a64          edge         jammy       cli                 stable                 adv
+olimex-teres-a64          edge         bookworm    desktop             stable                 adv	     gnome	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+olimex-teres-a64          edge         bullseye    desktop             stable                 yes	     cinnamon	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+olimex-teres-a64          edge         bullseye    desktop             stable                 yes	     xfce	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # nanopiduo


### PR DESCRIPTION
Linux 6.1.X has regression in mesa causing DRM issues such as 'DRM_IOCTL_MODE_CREATE_DUMB failed' see https://gitlab.freedesktop.org/mesa/mesa/-/issues/8198, the issue has been addressed in Linux 6.2.X with commit https://gitlab.freedesktop.org/mesa/mesa/-/commit/c426e5677f36c3b0b8e8ea199ed4f2c7fad06d47 thus using edge as it's currently using Linux 6.2.11

May introduce issues with armbian-firmware breaking display rendering, cause is not fully understood atm.