### PR TITLE
OLIMEX Teres-A64: Hotfix on legacy kernel

### DIFF
--- a/targets/default.conf
+++ b/targets/default.conf
@@ -237,11 +237,11 @@ lime-a64                  current         jammy       desktop                  s
 
 
 # Olimex Teres A64
-olimex-teres-a64          edge         bullseye    cli	               stable,nightly         yes
-olimex-teres-a64          edge         jammy       cli                 stable                 adv
-olimex-teres-a64          edge         bookworm    desktop             stable                 adv	     gnome	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-olimex-teres-a64          edge         bullseye    desktop             stable                 yes	     cinnamon	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-olimex-teres-a64          edge         bullseye    desktop             stable                 yes	     xfce	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+olimex-teres-a64          legacy         bullseye    cli	               stable,nightly         yes
+olimex-teres-a64          legacy         jammy       cli                 stable                 adv
+olimex-teres-a64          legacy         bookworm    desktop             stable                 adv	     gnome	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+olimex-teres-a64          legacy         bullseye    desktop             stable                 yes	     cinnamon	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+olimex-teres-a64          legacy         bullseye    desktop             stable                 yes	     xfce	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
 
 
 # nanopiduo


### PR DESCRIPTION
Despite setting the kernel on edge, armbian still ships it with Linux 6.1 so this is a hotfix to use legacy until linux 6.2.X is released for sunxi. To clarify the edge solution works, but after installing any package it forces downgrade to the broken kernel.

Optionally bump the kernel for sunxi on 6.2.X