### PR TITLE
update chunk templates for better logs and being able to cancel the workflow

### DIFF
--- a/userpatches/gha/chunks/050.single_header.yaml
+++ b/userpatches/gha/chunks/050.single_header.yaml
@@ -206,6 +206,11 @@ jobs:
           cd build
           bash ./compile.sh gha-matrix [[userpatches_config_for_prepare_job]] CLEAN_INFO=yes CLEAN_MATRIX=yes MATRIX_ARTIFACT_CHUNKS=[[num_chunks_artifacts]] MATRIX_IMAGE_CHUNKS=[[num_chunks_images]] CHECK_OCI=${{ github.event.inputs.checkOci }} TARGETS_FILENAME=targets.yaml SKIP_IMAGES=${{ github.event.inputs.skipImages }} ${{env.EXTRA_PARAMS_ALL_BUILDS}} SHARE_LOG=yes #  IMAGES_ONLY_OUTDATED_ARTIFACTS=yes
 
+      - name: "Logs: ${{ steps.prepare-matrix.outputs.logs_url }}"
+        if: always()
+        run: |
+          echo "Logs: ${{ steps.prepare-matrix.outputs.logs_url }}"
+
       - name: chown cache memoize/oci back to normal user
         run: sudo chown -R $USER:$USER build/cache/memoize build/cache/oci/positive
 

--- a/userpatches/gha/chunks/250.single_aggr-jobs.yaml
+++ b/userpatches/gha/chunks/250.single_aggr-jobs.yaml
@@ -6,7 +6,7 @@ jobs: # <TEMPLATE-IGNORE>
   all-artifacts-ready:
     name: "[[num_chunks_artifacts]] artifacts chunks ready"
     runs-on: ubuntu-latest # not going to run, anyway, but is required.
-    if: ${{ always() && ( 1 == 2 ) }} # eg: never run.
+    if: ${{ !cancelled() && ( 1 == 2 ) }} # eg: never run.
     needs: [ "matrix_prep", "[[ quoted_comma_list_artifact_chunk_jobs ]]" ] # <-- HERE: all artifact chunk numbers.
     steps:
       - name: fake step
@@ -15,7 +15,7 @@ jobs: # <TEMPLATE-IGNORE>
   all-images-ready:
     name: "[[num_chunks_images]] image chunks ready"
     runs-on: ubuntu-latest # not going to run, anyway, but is required.
-    if: ${{ always() && ( 1 == 2 ) }} # eg: never run.
+    if: ${{ !cancelled() && ( 1 == 2 ) }} # eg: never run.
     needs: [ "matrix_prep", "[[ quoted_comma_list_image_chunk_jobs ]]" ] # <-- HERE: all image chunk numbers.
     steps:
       - name: fake step
@@ -24,7 +24,7 @@ jobs: # <TEMPLATE-IGNORE>
   all-artifacts-and-images-ready:
     name: "[[num_chunks_artifacts]] artifacts and [[num_chunks_images]] image chunks ready"
     runs-on: ubuntu-latest # not going to run, anyway, but is required.
-    if: ${{ always() && ( 1 == 2 ) }} # eg: never run.
+    if: ${{ !cancelled() && ( 1 == 2 ) }} # eg: never run.
     needs: [ "matrix_prep", "all-artifacts-ready", "all-images-ready" ]
     steps:
       - name: fake step

--- a/userpatches/gha/chunks/550.per-chunk-artifacts_job.yaml
+++ b/userpatches/gha/chunks/550.per-chunk-artifacts_job.yaml
@@ -58,6 +58,11 @@ jobs: # <TEMPLATE-IGNORE>
         run: |
           bash ./compile.sh ${{ matrix.invocation }} SHARE_LOG=yes ${{env.EXTRA_PARAMS_ALL_BUILDS}}
 
+      - name: "Logs: ${{ steps.build.outputs.logs_url }}"
+        if: always()
+        run: |
+          echo "Logs: ${{ steps.build.outputs.logs_url }}"
+
       - name: Install SSH key for storage
         env:
           KEY_ARMBIAN_UPLOAD: ${{ secrets.KEY_ARMBIAN_UPLOAD }}

--- a/userpatches/gha/chunks/650.per-chunk-images_job.yaml
+++ b/userpatches/gha/chunks/650.per-chunk-images_job.yaml
@@ -4,7 +4,7 @@ jobs: # <TEMPLATE-IGNORE>
   "TEMPLATE-JOB-NAME": # <TEMPLATE-JOB-NAME>
     needs: [ "matrix_prep", "all-artifacts-ready" ]
     timeout-minutes: 90
-    if: ${{ always() && ( github.repository_owner == '[[org]]' ) && ( needs.matrix_prep.outputs.images-chunk-not-empty-[[chunk]] == 'yes' ) }} # <-- HERE: Chunk number.
+    if: ${{ !failure() && !cancelled() && ( github.repository_owner == '[[org]]' ) && ( needs.matrix_prep.outputs.images-chunk-not-empty-[[chunk]] == 'yes' ) }} # <-- HERE: Chunk number.
     strategy:
       fail-fast: false # let other jobs try to complete if one fails
       matrix: ${{ fromJSON(needs.matrix_prep.outputs.images-chunk-json-[[chunk]]) }} # <-- HERE: Chunk number.
@@ -54,6 +54,11 @@ jobs: # <TEMPLATE-IGNORE>
         id: build-one-image
         run: |
           bash ./compile.sh ${{ matrix.invocation }} SHARE_LOG=yes MAKE_FOLDERS="archive" IMAGE_VERSION=${{ needs.matrix_prep.outputs.version }} ${{env.EXTRA_PARAMS_IMAGE}} ${{env.EXTRA_PARAMS_ALL_BUILDS}}
+
+      - name: "Logs: ${{ steps.build-one-image.outputs.logs_url }}"
+        if: always()
+        run: |
+          echo "Logs: ${{ steps.build-one-image.outputs.logs_url }}"
 
       - name: Install SSH key for storage
         env:


### PR DESCRIPTION
gha/chunks: 
- avoid using `always()` in `job.if`, otherwise jobs can't be cancelled; 
- add step showing the SHARE_LOG=yes URL separately so easy to get to the logs (requires https://github.com/armbian/build/pull/5186 but shouldn't fail without it, just be empty)
