### PR TITLE
Enable Team Membership Check to improve security

### DIFF
--- a/.github/workflows/build-nightly-images.yml
+++ b/.github/workflows/build-nightly-images.yml
@@ -1,4 +1,4 @@
-name: Build Nightly Images
+name: Build Nightly Images (admin)
 on:
   repository_dispatch:
     types: ["Build Nightly Images"]
@@ -25,23 +25,14 @@ jobs:
           token: ${{ secrets.GITHUB_TOKEN }}
           days_old: 7
 
-#  Kernel:
-#    name: "Update kernel cache"
-#    needs: Prepare
-#    if: ${{ github.repository_owner == 'Armbian' }}
-#    uses: armbian/scripts/.github/workflows/build-kernel-cache.yml@main
-#    with:
-#      ACCESS_NAME: igorpecovnik
-#      BUILD_BRANCH: ${{ inputs.BUILD_BRANCH }}
-#      BUILD_RUNNER: ${{ inputs.BUILD_RUNNER }}
-#    secrets:
-#      ACCESS_TOKEN: ${{ secrets.ACCESS_TOKEN }}
-#      KEY_TORRENTS: ''
-#      KNOWN_HOSTS_UPLOAD: ''
+      - name: "Check membership"
+        uses: armbian/actions/team-check@main
+        with:
+          ORG_MEMBERS: ${{ secrets.ORG_MEMBERS }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generaterelease:
 
-    #needs: Kernel
     needs: Prepare
     name: "Generate release"
     if: ${{ github.repository_owner == 'Armbian' }}

--- a/.github/workflows/build-nightly-images.yml
+++ b/.github/workflows/build-nightly-images.yml
@@ -1,4 +1,4 @@
-name: Build Nightly Images (admin)
+name: Build Nightly Images (admin/old)
 on:
   repository_dispatch:
     types: ["Build Nightly Images"]

--- a/.github/workflows/enable-hetzner-runners.yml
+++ b/.github/workflows/enable-hetzner-runners.yml
@@ -43,7 +43,31 @@ concurrency:
 
 jobs:
 
+  Teamcheck:
+    permissions:
+      actions: write
+      
+    name: "Check ORG Team Membership"
+    if: ${{ github.repository_owner == 'Armbian' }}
+    runs-on: ubuntu-latest
+    steps:
+
+    -  uses: tspascoal/get-user-teams-membership@v2
+       id: checkUserMember
+       with:
+         username: ${{ github.actor }}
+         organization: armbian
+         team: "Release manager"
+         GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
+         
+    - name: Cancel if not a part of the team
+      if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+      uses: "andymckay/cancel-action@0.3"
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+
   Prepare:
+    needs: Teamcheck
     name: "Enable cloud runners"
     outputs:
       matrix: ${{steps.machine-number.outputs.matrix}}

--- a/.github/workflows/enable-hetzner-runners.yml
+++ b/.github/workflows/enable-hetzner-runners.yml
@@ -52,19 +52,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    -  uses: tspascoal/get-user-teams-membership@v2
-       id: checkUserMember
-       with:
-         username: ${{ github.actor }}
-         organization: armbian
-         team: "Release manager"
-         GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
-         
-    - name: Cancel if not a part of the team
-      if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-      uses: "andymckay/cancel-action@0.3"
+    - name: "Check membership"
+      uses: armbian/actions/team-check@main
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
+        ORG_MEMBERS: ${{ secrets.ORG_MEMBERS }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   Prepare:
     needs: Teamcheck

--- a/.github/workflows/enable-hetzner-runners.yml
+++ b/.github/workflows/enable-hetzner-runners.yml
@@ -1,4 +1,4 @@
-name: Enable Hetzner Runners
+name: Enable Hetzner Runners (admin)
 on:
   workflow_dispatch:
     inputs:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,12 +20,15 @@ on:
 #      - completed
 
 permissions:
-  contents: write
+  contents: read
 
 jobs:
 
   Teamcheck:
-
+  
+    permissions:
+      actions: write
+      
     name: "Check Team Membership"
     if: ${{ github.repository_owner == 'Armbian' }}
     runs-on: ubuntu-latest

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -31,7 +31,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     -  uses: tspascoal/get-user-teams-membership@v2
-       id: checkUserMember
+       id: actorTeams
        with:
          username: ${{ github.actor }}
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}    

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -33,20 +33,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
 
-    -  uses: tspascoal/get-user-teams-membership@v2
-       id: checkUserMember
-       with:
-         username: ${{ github.actor }}
-         organization: armbian
-         team: "Release manager"
-         GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
-         
-    - name: Cancel if not a part of the team
-      if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-      uses: "andymckay/cancel-action@0.3"
+    - name: "Check membership"
+      uses: armbian/actions/team-check@main
       with:
-        token: ${{ secrets.GITHUB_TOKEN }}
-      
+        ORG_MEMBERS: ${{ secrets.ORG_MEMBERS }}
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
   Smoke:
     needs: Teamcheck
     permissions:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -34,12 +34,10 @@ jobs:
        id: checkUserMember
        with:
          username: ${{ github.actor }}
-         team: 'release-manager'
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}    
-    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
-      run: 
-        echo "Yes"
-        
+    - if: ${{ !(contains(steps.actorTeams.outputs.teams, 'A team members') || contains(steps.actorTeams.outputs.teams.teams, 'A team admins')) }}
+      name: Label PR as external contribution
+      
   Smoke:
     needs: Teamcheck
     permissions:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -41,6 +41,8 @@ jobs:
     - name: Label PR as external contribution
       if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
       uses: "andymckay/cancel-action@0.3"
+      with:
+        access_token: ${{ secrets.GITHUB_TOKEN }}
       
   Smoke:
     needs: Teamcheck

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -25,7 +25,6 @@ permissions:
 jobs:
 
   Teamcheck:
-  
     permissions:
       actions: write
       
@@ -33,6 +32,7 @@ jobs:
     if: ${{ github.repository_owner == 'Armbian' }}
     runs-on: ubuntu-latest
     steps:
+
     -  uses: tspascoal/get-user-teams-membership@v2
        id: checkUserMember
        with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -35,7 +35,7 @@ jobs:
        with:
          username: ${{ github.actor }}
          organization: armbian
-         team: release-manager
+         team: "Website"
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
          
     - name: Label PR as external contribution

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -28,7 +28,7 @@ jobs:
     permissions:
       actions: write
       
-    name: "Check Team Membership"
+    name: "Check ORG Team Membership"
     if: ${{ github.repository_owner == 'Armbian' }}
     runs-on: ubuntu-latest
     steps:
@@ -41,7 +41,7 @@ jobs:
          team: "Release manager"
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
          
-    - name: Label PR as external contribution
+    - name: Cancel if not a part of the team
       if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
       uses: "andymckay/cancel-action@0.3"
       with:

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -37,6 +37,8 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}    
     - if: ${{ !(contains(steps.actorTeams.outputs.teams, 'A team members') || contains(steps.actorTeams.outputs.teams.teams, 'A team admins')) }}
       name: Label PR as external contribution
+      run: |
+        echo "tzest"
       
   Smoke:
     needs: Teamcheck

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -24,7 +24,26 @@ permissions:
 
 jobs:
 
+  Teamcheck:
+
+    name: "Generate release"
+    if: ${{ github.repository_owner == 'Armbian' }}
+    runs-on: ubuntu-latest
+    outputs:
+      version: ${{steps.releases.outputs.version}}
+    steps:
+    -  uses: tspascoal/get-user-teams-membership@v2
+       id: checkUserMember
+       with:
+         username: ${{ github.actor }}
+         team: 'octocats'
+         GITHUB_TOKEN: ${{ secrets.PAT }}    
+    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+      run: 
+        echo "Yes"
+        
   Smoke:
+    needs: Teamcheck
     permissions:
       contents: none
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -1,4 +1,4 @@
-name: Smoke tests on DUTs
+name: Smoke tests on DUTs (admin)
 #
 # Runs varios tests with latest nighly codebase on a real hardware
 #

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -20,7 +20,7 @@ on:
 #      - completed
 
 permissions:
-  contents: read
+  contents: write
 
 jobs:
 

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -42,7 +42,7 @@ jobs:
       if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
       uses: "andymckay/cancel-action@0.3"
       with:
-        access_token: ${{ secrets.GITHUB_TOKEN }}
+        token: ${{ secrets.GITHUB_TOKEN }}
       
   Smoke:
     needs: Teamcheck

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -31,14 +31,16 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     -  uses: tspascoal/get-user-teams-membership@v2
-       id: actorTeams
+       id: checkUserMember
        with:
          username: ${{ github.actor }}
-         GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}    
-    - if: ${{ !(contains(steps.actorTeams.outputs.teams, 'A team members') || contains(steps.actorTeams.outputs.teams.teams, 'A team admins')) }}
-      name: Label PR as external contribution
+         organization: armbian
+         team: release-manager
+         GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
+         
+    - name: Label PR as external contribution
       run: |
-        echo "tzest"
+        echo "Is: ${{ steps.checkUserMember.outputs.isTeamMember }}"
       
   Smoke:
     needs: Teamcheck

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -35,7 +35,7 @@ jobs:
        with:
          username: ${{ github.actor }}
          organization: armbian
-         team: "Website"
+         team: "Release manager"
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
          
     - name: Label PR as external contribution

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -39,8 +39,9 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
          
     - name: Label PR as external contribution
+      if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
       run: |
-        echo "Is: ${{ steps.checkUserMember.outputs.isTeamMember }}"
+        echo "Is: Yes ${{ steps.checkUserMember.outputs.isTeamMember }}"
       
   Smoke:
     needs: Teamcheck

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -37,7 +37,7 @@ jobs:
        with:
          username: ${{ github.actor }}
          team: 'octocats'
-         GITHUB_TOKEN: ${{ secrets.PAT }}    
+         GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}    
     - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
       run: 
         echo "Yes"

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -26,11 +26,9 @@ jobs:
 
   Teamcheck:
 
-    name: "Generate release"
+    name: "Check Team Membership"
     if: ${{ github.repository_owner == 'Armbian' }}
     runs-on: ubuntu-latest
-    outputs:
-      version: ${{steps.releases.outputs.version}}
     steps:
     -  uses: tspascoal/get-user-teams-membership@v2
        id: checkUserMember

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -36,7 +36,7 @@ jobs:
          username: ${{ github.actor }}
          team: 'release-manager'
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}    
-    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
+    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
       run: 
         echo "Yes"
         

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -39,9 +39,8 @@ jobs:
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}
          
     - name: Label PR as external contribution
-      if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
-      run: |
-        echo "Is: Yes ${{ steps.checkUserMember.outputs.isTeamMember }}"
+      if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+      uses: "andymckay/cancel-action@0.3"
       
   Smoke:
     needs: Teamcheck

--- a/.github/workflows/smoke-tests.yml
+++ b/.github/workflows/smoke-tests.yml
@@ -36,9 +36,9 @@ jobs:
        id: checkUserMember
        with:
          username: ${{ github.actor }}
-         team: 'octocats'
+         team: 'release-manager'
          GITHUB_TOKEN: ${{ secrets.ORG_MEMBERS }}    
-    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'false' }}
+    - if: ${{ steps.checkUserMember.outputs.isTeamMember == 'true' }}
       run: 
         echo "Yes"
         


### PR DESCRIPTION
Only members of team "Release Manager" can trigger:

- smoke tests
- enable additional runners
- nightly images (old)