### PR TITLE
Enable watchdog to restart failed jobs

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,8 @@ jobs:
           read ID STATUS ATTEMPT <<< $(gh api "/repos/${OWNER_REPO}/actions/workflows/${WORKFLOW}/runs" | jq '.workflow_runs[]' | jq -r '.id,.conclusion,.run_attempt' | head -3 | xargs -n3 -d'\n')
           echo "ID=$ID STATUS=$STATUS ATTEMPT=$ATTEMPT"
           
-          # if attempt is lower then 5 and status is "failure", rerun failed jobs
+          # if attempt is lower then 5 and status is not "success", rerun failed jobs
           
-          if [ "${ATTEMPT}" -lt 5 ] && [ "$STATUS" == "failure" ]; then          
+          if [ "${ATTEMPT}" -lt 5 ] && [ "$STATUS" != "success" ]; then          
           gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${OWNER_REPO}/actions/runs/${ID}/rerun-failed-jobs
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -25,6 +25,6 @@ jobs:
           echo "ID=$ID STATUS=$STATUS ATTEMPT=$ATTEMPT"
           
           # if attempt is lower then 5 and status is "cancelled" or "failed", rerun failed jobs
-          if [ "${ATTEMPT}" -lt 5 ] && ([ "$STATUS" == "failure" ] || [ "$STATUS" == "canceled" ]); then
+          if [ "${ATTEMPT}" -lt 5 ] && ([ "$STATUS" == "failure" ] || [ "$STATUS" == "cancelled" ]); then
           gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${OWNER_REPO}/actions/runs/${ID}/rerun-failed-jobs
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -24,8 +24,7 @@ jobs:
           read ID STATUS ATTEMPT <<< $(gh api "/repos/${OWNER_REPO}/actions/workflows/${WORKFLOW}/runs" | jq '.workflow_runs[]' | jq -r '.id,.conclusion,.run_attempt' | head -3 | xargs -n3 -d'\n')
           echo "ID=$ID STATUS=$STATUS ATTEMPT=$ATTEMPT"
           
-          # if attempt is lower then 5 and status is not "success", rerun failed jobs
-          
-          if [ "${ATTEMPT}" -lt 5 ] && [ "$STATUS" != "success" ]; then          
+          # if attempt is lower then 5 and status is "cancelled" or "failed", rerun failed jobs
+          if [ "${ATTEMPT}" -lt 5 ] && ([ "$STATUS" == "failure" ] || [ "$STATUS" == "canceled" ]); then
           gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${OWNER_REPO}/actions/runs/${ID}/rerun-failed-jobs
           fi

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,49 +1,31 @@
-name: "TST"
+#
+# This action recreate action for building stable images
+#
+name: Watchdog
 on:
+  schedule:
+    - cron: '*/15 * * * *'   
   workflow_dispatch:
-  workflow_call:
+
+env:
+  GH_TOKEN: ${{ secrets.ACCESS_TOKEN_ARMBIANWORKER }}
 
 jobs:
 
-  Prepare:
-    permissions:
-      actions: write
-    name: "Team"
-    runs-on: [ubuntu-latest]
+  Check:
+    name: "Watchdog"
+    runs-on: ubuntu-latest
     steps:
 
-      - name: "Check membership"
-        uses: armbian/actions/team-check@main
-        with:
-          ORG_MEMBERS: ${{ secrets.ORG_MEMBERS }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  Test:
-    needs: "Prepare"
-    runs-on: [ubuntu-latest]
-    steps:
-
-      - name: Install SSH key for storage
-        env:
-          KEY_ARMBIAN_UPLOAD: ${{ secrets.KEY_ARMBIAN_UPLOAD }}
-        if: env.KEY_ARMBIAN_UPLOAD != null
-        uses: shimataro/ssh-key-action@v2
-        with:
-          key: ${{ secrets.KEY_ARMBIAN_UPLOAD }}
-          known_hosts: ${{ secrets.KNOWN_HOSTS_ARMBIAN_UPLOAD }}
-          if_key_exists: replace
-
-      - name: Get content from server
-        timeout-minutes: 180
-        env:
-          KEY_ARMBIAN_UPLOAD: ${{ secrets.KEY_ARMBIAN_UPLOAD }}
-          ARMBIAN_HOST_UPLOAD: ${{ secrets.ARMBIAN_HOST_UPLOAD }}
-
-        if: env.KEY_ARMBIAN_UPLOAD != null && env.ARMBIAN_HOST_UPLOAD != null
+      - name: "Read status"
         run: |
-
-          if ! command -v "lftp" > /dev/null 2>&1; then
-             sudo apt-get -y -qq install lftp
+          OWNER_REPO="armbian/os"
+          WORKFLOW=$(gh api "/repos/${OWNER_REPO}/actions/workflows" | jq '.workflows[] | select(.name=="Build Nightly Images (cronjob)")' | jq -r '.id')
+          read ID STATUS ATTEMPT <<< $(gh api "/repos/${OWNER_REPO}/actions/workflows/${WORKFLOW}/runs" | jq '.workflow_runs[]' | jq -r '.id,.conclusion,.run_attempt' | head -3 | xargs -n3 -d'\n')
+          echo "ID=$ID STATUS=$STATUS ATTEMPT=$ATTEMPT"
+          
+          # if attempt is lower then 5 and status is "failure", rerun failed jobs
+          
+          if [ "${ATTEMPT}" -lt 5 ] && [ "$STATUS" == "failure" ]; then          
+          gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${OWNER_REPO}/actions/runs/${ID}/rerun-failed-jobs
           fi
-
-          lftp -u upload, -e "set net:timeout 4;set net:max-retries 6;find -l debs/;bye" sftp://${{ env.ARMBIAN_HOST_UPLOAD }} > x.txt
-          cat x.txt

--- a/.github/workflows/watchdog.yml
+++ b/.github/workflows/watchdog.yml
@@ -1,10 +1,10 @@
 #
 # This action recreate action for building stable images
 #
-name: Watchdog
+name: Watchdog (cronjob)
 on:
   schedule:
-    - cron: '*/15 * * * *'   
+    - cron: '*/15 * * * *'
   workflow_dispatch:
 
 env:
@@ -19,12 +19,17 @@ jobs:
 
       - name: "Read status"
         run: |
+
           OWNER_REPO="armbian/os"
+          ATTEMPTS="5"
+
           WORKFLOW=$(gh api "/repos/${OWNER_REPO}/actions/workflows" | jq '.workflows[] | select(.name=="Build Nightly Images (cronjob)")' | jq -r '.id')
           read ID STATUS ATTEMPT <<< $(gh api "/repos/${OWNER_REPO}/actions/workflows/${WORKFLOW}/runs" | jq '.workflow_runs[]' | jq -r '.id,.conclusion,.run_attempt' | head -3 | xargs -n3 -d'\n')
+
+          # Debug print
           echo "ID=$ID STATUS=$STATUS ATTEMPT=$ATTEMPT"
-          
+
           # if attempt is lower then 5 and status is "cancelled" or "failed", rerun failed jobs
-          if [ "${ATTEMPT}" -lt 5 ] && ([ "$STATUS" == "failure" ] || [ "$STATUS" == "cancelled" ]); then
+          if [ "${ATTEMPT}" -lt "${ATTEMPTS}" ] && ([ "$STATUS" == "failure" ] || [ "$STATUS" == "cancelled" ]); then
           gh api --method POST -H "Accept: application/vnd.github+json" -H "X-GitHub-Api-Version: 2022-11-28" /repos/${OWNER_REPO}/actions/runs/${ID}/rerun-failed-jobs
           fi


### PR DESCRIPTION
Nightly images creation often fails to complete. Lets run watchdog to re-run them up to 5 times.