### PR TITLE
`targets-all-not-eos.yaml`: use new `userspace:` inventory; use self-hosted runners for rootfs builds

### DIFF
--- a/userpatches/targets-all-not-eos.yaml
+++ b/userpatches/targets-all-not-eos.yaml
@@ -1,5 +1,6 @@
 #
-# This config generates all artefacts except for EOS targets
+# This config generates all artefacts except for EOS targets.
+# Also, rootfs/base-files/armbian-desktop for all userspace distros and desktops that are not EOS.
 #
 common-gha-configs:
   armbian-gha: &armbian-gha
@@ -9,55 +10,41 @@ common-gha-configs:
         kernel: [ "self-hosted", "Linux", "alfa" ]
         uboot: [ "self-hosted", "Linux", "fast", "X64" ]
         armbian-bsp-cli: [ "fast" ]
+      by-name-and-arch:
+        rootfs-armhf: [ "self-hosted", "Linux", "ARM64" ]
+        rootfs-arm64: [ "self-hosted", "Linux", "ARM64" ]
+        rootfs-amd64: [ "self-hosted", "Linux", "X64" ]
+        rootfs-riscv64: [ "self-hosted", "Linux", "X64" ]
 
 targets:
 
-  all-base-files-and-rootfs-cli-minimal:
+  all-userspace:
     configs: [ armbian-images ]
     pipeline:
       build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "rootfs" ] # only armbian-base-files and rootfs artifacts
+      only-artifacts: [ "armbian-base-files", "armbian-desktop", "rootfs" ] # only these artifacts
       gha: *armbian-gha
-    expand: # expand causes the items matrix to multiply. if you have X items, and 6 expands, you'll get 6X items. In this case, 3 items, 6 expands, total 18 items.
-      jammy:
-        RELEASE: "jammy"
-      lunar:
-        RELEASE: "lunar"
-      bullseye:
-        RELEASE: "bullseye"
-      bookworm:
-        RELEASE: "bookworm"
-      trixie:
-        RELEASE: "trixie"
-      sid:
-        RELEASE: "sid"
-    vars: # common vars. both the items and the expansions can override these.
-      BUILD_MINIMAL: "yes"
-      BUILD_DESKTOP: "no"
-    items:
-      - { BOARD: uefi-arm64, BRANCH: current } # arm64
-      - { BOARD: uefi-x86, BRANCH: current } # amd64
-      - { BOARD: tinkerboard, BRANCH: current } # armhf
-      # riscv64 needs to be done in a separate target, since only sid supports it
+    vars: # common vars, must exist.
+      USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
+    items-from-inventory:
+      userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
+        #skip-releases: [ "sid" ] # do NOT include these releases
+        #only-releases: ["trixie", "bookworm", "bullseye"] # ONLY include these releases
+        skip-desktops: [ "lxde" ] # do NOT include these desktops
+        #only-desktops: ["gnome", "xfce"] # ONLY include these desktops
+        cli: yes # include normal CLI userspace
+        minimal: yes # include minimal CLI userspace
+        desktops: yes # include desktops, one per desktop_variations below; 'eos' ones are always skipped
+        desktop_variations:
+          - [ ] # empty, no appgroups, simple desktop
+          - [ 3dsupport,browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # 3d + all
+          - [ browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # all except 3d
+        arches: # wanted architectures, and their "example" BOARD and BRANCH.
+          arm64: [ { BOARD: "uefi-arm64", BRANCH: "current" } ]
+          armhf: [ { BOARD: "tinkerboard", BRANCH: "current" } ]
+          amd64: [ { BOARD: "uefi-x86", BRANCH: "current" } ]
+          riscv64: [ { BOARD: "uefi-riscv64", BRANCH: "edge" } ]
 
-  riscv64-base-files-and-rootfs-cli-minimal:
-    configs: [ armbian-images ]
-    pipeline:
-      build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "rootfs" ] # only armbian-base-files and rootfs artifacts
-      gha: *armbian-gha
-    expand: # expand causes the items matrix to multiply. if you have X items, and 6 expands, you'll get 6X items. In this case, 3 items, 6 expands, total 18 items.
-      lunar:
-        RELEASE: "lunar"
-      #trixie: # one day
-      #  RELEASE: "trixie"
-      sid:
-        RELEASE: "sid"
-    vars: # common vars. both the items and the expansions can override these.
-      BUILD_MINIMAL: "yes"
-      BUILD_DESKTOP: "no"
-    items:
-      - { BOARD: uefi-riscv64, BRANCH: current } # riscv64
 
   all-desktop:
     enabled: yes


### PR DESCRIPTION
#### `targets-all-not-eos.yaml`: use new `userspace:` inventory; use self-hosted runners for rootfs builds