### PR TITLE
Split rootfs creation from all artifacts

### DIFF
--- a/.github/workflows/recreate-matrix.yml
+++ b/.github/workflows/recreate-matrix.yml
@@ -122,6 +122,19 @@ jobs:
         sed -i "s/pipeline-/pipeline-all/" output/info/artifact-image-complete-matrix.yml
         cp output/info/artifact-image-complete-matrix.yml ../os/.github/workflows/complete-artifact-matrix-all.yml
 
+        #
+        # copy roofs templates
+        #
+        cp userpatches/gha/gha_config_rootfs.yaml userpatches/gha/gha_config.yaml
+        cp userpatches/targets-rootfs.yaml userpatches/targets.yaml
+        bash ./compile.sh gha-template
+        # add boards and maintainers
+        sed -i '/# boards/r /tmp/boards.txt' output/info/artifact-image-complete-matrix.yml
+        sed -i '/# maintainers/r /tmp/maintainers.txt' output/info/artifact-image-complete-matrix.yml
+        # we need unique concurency id
+        sed -i "s/pipeline-/pipeline-rootfs/" output/info/artifact-image-complete-matrix.yml
+        cp output/info/artifact-image-complete-matrix.yml ../os/.github/workflows/complete-artifact-matrix-rootfs.yml
+
         cd ../os
         git config --local user.email "info@armbian.com"
         git config --local user.name "Armbianworker"
@@ -131,6 +144,7 @@ jobs:
         #git add .github/workflows/complete-artifact-matrix-old-stable.yml
         git add .github/workflows/complete-artifact-matrix-stable.yml
         git add .github/workflows/complete-artifact-matrix-all.yml
+        git add .github/workflows/complete-artifact-matrix-rootfs.yml
 
         git commit --allow-empty -m "Update generated GHA chunk workflow artifact-image-complete-matrix.yml" -a
 

--- a/userpatches/gha/gha_config_roofs.yaml
+++ b/userpatches/gha/gha_config_roofs.yaml
@@ -1,0 +1,29 @@
+org: "armbian" # can't be an expression, only string.
+
+# armbian/build coordinates
+org_and_build_repo: "armbian/build"
+build_ref: "main"
+script_name: "Build Rootfs cache (cronjob)"
+concurrency_group: "pipeline"
+repository_ref: "rootfs"
+
+# menu defaults
+skipImagesDefaults: "'yes'"
+checkOciDefaults: "'yes'"
+nightlybuildDefaults: "'yes'"
+uploadtoserverDefaults: "'github'"
+
+# armbian/os coordinates. set all to empty to not use userpatches.
+org_and_userpatches_repo: "armbian/os"
+userpatches_ref: "main"
+userpatches_dir: "userpatches" # folder inside the userpatches repo; use "." if stuff is in the root of the repo
+targets_filename: "targets-all-not-eos.yaml"
+
+ghcr_user: "${{ github.repository_owner }}"
+userpatches_config_for_prepare_job: "armbian-images" # use "" for no config file
+
+# repository runner
+repository_runner: "[ repository ]"
+
+# when this should run
+cron_job: "schedule:\n   - cron: '0 1 * * *'"

--- a/userpatches/targets-all-not-eos.yaml
+++ b/userpatches/targets-all-not-eos.yaml
@@ -18,34 +18,6 @@ common-gha-configs:
 
 targets:
 
-  all-userspace:
-    configs: [ armbian-images ]
-    pipeline:
-      build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "armbian-desktop", "rootfs" ] # only these artifacts
-      gha: *armbian-gha
-    vars: # common vars, must exist.
-      USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
-    items-from-inventory:
-      userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
-        #skip-releases: [ "sid" ] # do NOT include these releases
-        #only-releases: ["trixie", "bookworm", "bullseye"] # ONLY include these releases
-        skip-desktops: [ "lxde" ] # do NOT include these desktops
-        #only-desktops: ["gnome", "xfce"] # ONLY include these desktops
-        cli: yes # include normal CLI userspace
-        minimal: yes # include minimal CLI userspace
-        desktops: yes # include desktops, one per desktop_variations below; 'eos' ones are always skipped
-        desktop_variations:
-          - [ ] # empty, no appgroups, simple desktop
-          - [ 3dsupport,browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # 3d + all
-          - [ browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # all except 3d
-        arches: # wanted architectures, and their "example" BOARD and BRANCH.
-          arm64: [ { BOARD: "uefi-arm64", BRANCH: "current" } ]
-          armhf: [ { BOARD: "tinkerboard", BRANCH: "current" } ]
-          amd64: [ { BOARD: "uefi-x86", BRANCH: "current" } ]
-          riscv64: [ { BOARD: "uefi-riscv64", BRANCH: "edge" } ]
-
-
   all-desktop:
     enabled: yes
     configs: [ armbian-images ]

--- a/userpatches/targets-rootfs.yaml
+++ b/userpatches/targets-rootfs.yaml
@@ -1,0 +1,47 @@
+#
+# This config generates all artefacts except for EOS targets.
+# Also, rootfs/base-files/armbian-desktop for all userspace distros and desktops that are not EOS.
+#
+common-gha-configs:
+  armbian-gha: &armbian-gha
+    runners:
+      default: "ubuntu-latest"
+      by-name:
+        kernel: [ "self-hosted", "Linux", "alfa" ]
+        uboot: [ "self-hosted", "Linux", "fast", "X64" ]
+        armbian-bsp-cli: [ "fast" ]
+      by-name-and-arch:
+        rootfs-armhf: [ "self-hosted", "Linux", "ARM64" ]
+        rootfs-arm64: [ "self-hosted", "Linux", "ARM64" ]
+        rootfs-amd64: [ "self-hosted", "Linux", "X64" ]
+        rootfs-riscv64: [ "self-hosted", "Linux", "X64" ]
+
+targets:
+
+  all-userspace:
+    configs: [ armbian-images ]
+    pipeline:
+      build-image: no # don't build images for this
+      only-artifacts: [ "armbian-base-files", "armbian-desktop", "rootfs" ] # only these artifacts
+      gha: *armbian-gha
+    vars: # common vars, must exist.
+      USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
+    items-from-inventory:
+      userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
+        #skip-releases: [ "sid" ] # do NOT include these releases
+        #only-releases: ["trixie", "bookworm", "bullseye"] # ONLY include these releases
+        skip-desktops: [ "lxde" ] # do NOT include these desktops
+        #only-desktops: ["gnome", "xfce"] # ONLY include these desktops
+        cli: yes # include normal CLI userspace
+        minimal: yes # include minimal CLI userspace
+        desktops: yes # include desktops, one per desktop_variations below; 'eos' ones are always skipped
+        desktop_variations:
+          - [ ] # empty, no appgroups, simple desktop
+          - [ 3dsupport,browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # 3d + all
+          - [ browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # all except 3d
+        arches: # wanted architectures, and their "example" BOARD and BRANCH.
+          arm64: [ { BOARD: "uefi-arm64", BRANCH: "current" } ]
+          armhf: [ { BOARD: "tinkerboard", BRANCH: "current" } ]
+          amd64: [ { BOARD: "uefi-x86", BRANCH: "current" } ]
+          riscv64: [ { BOARD: "uefi-riscv64", BRANCH: "edge" } ]
+


### PR DESCRIPTION
This prevent blocking of regular flow in case of upstream packages troubles. This is especially common on Sid.