### PR TITLE
uefi-arm64: add edge kernel to nightlies

### DIFF
--- a/userpatches/targets-release-nightly.yaml
+++ b/userpatches/targets-release-nightly.yaml
@@ -127,6 +127,7 @@ lists:
     - { BOARD: station-p1, BRANCH: current }
     - { BOARD: station-p2, BRANCH: current }
     - { BOARD: uefi-arm64, BRANCH: current }
+    - { BOARD: uefi-arm64, BRANCH: edge }
 
   full-desktop-3d: &full-desktop-3d
     # debian stable minimal


### PR DESCRIPTION
now that we're starting to see more opportunities for UEFI ex: sweet potato.. having edge kernel really helps.