### PR TITLE
OLIMEX Teres-A64: Update default targets

### DIFF
--- a/targets/default.conf
+++ b/targets/default.conf
@@ -251,11 +251,21 @@ lime-a64                  current         jammy       desktop                  s
 
 
 # Olimex Teres A64
-olimex-teres-a64          current      bookworm    cli	               stable,nightly         yes
-olimex-teres-a64          current      jammy       cli                 stable                 adv
-olimex-teres-a64          current      bookworm    desktop             stable                 adv	     gnome	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-olimex-teres-a64          current      bookworm    desktop             stable                 yes	     cinnamon	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
-olimex-teres-a64          current      bookworm    desktop             stable                 yes	     xfce	   config_base	 3dsupport,browsers,chat,desktop_tools,editors,email,internet,multimedia,office,programming,remote_desktop
+olimex-teres-a64          current         jammy       minimal                  stable         adv
+olimex-teres-a64          current         bookworm    minimal                  stable         adv
+## Desktop releases - Debian
+olimex-teres-a64          current         bookworm    desktop	                 stable         yes            gnome         config_base   none
+olimex-teres-a64          current         bookworm    desktop                  stable         yes	           cinnamon	     config_base   none
+olimex-teres-a64          current         bookworm    desktop                  stable         yes	           xfce	         config_base   none
+## Desktop releases - Ubuntu
+olimex-teres-a64          current         jammy       desktop	                 stable         yes            gnome         config_base   none
+olimex-teres-a64          current         jammy       desktop                  stable         yes	           cinnamon	     config_base   none
+olimex-teres-a64          current         jammy       desktop                  stable         yes	           xfce	         config_base   none
+## Testing releases
+olimex-teres-a64          edge            trixie      minimal                  nightly        no
+olimex-teres-a64          edge            trixie      desktop	                 nightly        no             gnome         config_base   none
+olimex-teres-a64          edge            trixie      desktop                  nightly        no	           cinnamon	     config_base   none
+olimex-teres-a64          edge            trixie      desktop                  nightly        no	           xfce	         config_base   none
 
 nanopiduo2                 current         bookworm    cli                      stable         adv
 nanopiduo2                 current         jammy       cli                      stable         adv


### PR DESCRIPTION
By default it should:

1. Build a minimal stable release of debian and ubuntu
2. gnome, cinnamon, xfce for both of these releases (stable debian and ubuntu)
3. Upcoming release using edge kernel with debian testing minimal, gnome, cinnamon and xfce

Ubuntu is omitted from testing the next releases as it's terrible distro and it's use with the device in the wild is not known