### PR TITLE
targets-release-standard-support: Teres enable GNOME

### DIFF
--- a/userpatches/targets-release-standard-support.yaml
+++ b/userpatches/targets-release-standard-support.yaml
@@ -169,8 +169,8 @@ lists:
     - { BOARD: lepotato, BRANCH: current }
     - { BOARD: odroidn2, BRANCH: current }
     - { BOARD: odroidm1, BRANCH: edge }
+    - { BOARD: olimex-teres-a64, BRANCH: current }
     - { BOARD: orangepi3-lts, BRANCH: current }
-    - { BOARD: orangepi4-lts, BRANCH: current }
     - { BOARD: pinebook-pro, BRANCH: current }
     - { BOARD: renegade, BRANCH: current }
     - { BOARD: rock-3a, BRANCH: current }
@@ -237,6 +237,7 @@ lists:
     - { BOARD: nanopi-r6s, BRANCH: edge }
     - { BOARD: nanopi-r4s, BRANCH: current }
     - { BOARD: nanopi-r5s, BRANCH: edge }
+    - { BOARD: olimex-teres-a64, BRANCH: current }
     - { BOARD: orangepi-r1, BRANCH: current }
     - { BOARD: orangepi-r1plus, BRANCH: current }
     - { BOARD: orangepi-r1plus-lts, BRANCH: current }


### PR DESCRIPTION
Not sure if i am doing this correctly, i want GNOME for teres to be autobuilt