### PR TITLE
add deps for jammy chromium

### DIFF
--- a/external/chromium-aarch64-jammy.conf
+++ b/external/chromium-aarch64-jammy.conf
@@ -4,6 +4,6 @@ RELEASE=jammy
 TARGET=desktop
 METHOD=aptly
 INSTALL=chromium
-GLOB="Name (% chromium) | Name (% chromium-*)"
+GLOB="Name (% chromium) | Name (% chromium-*) | Name (% libdav1d7) | Name (% libharfbuzz-subset0) | Name (% libharfbuzz0b)"
 ARCH=arm64
 REPOSITORY=BS


### PR DESCRIPTION
Reported by user from discord:
```
sudo apt install chromium=9:125.0.6422.60-1+j1armbian1 chromium-common=125.0.6422.60-1+j1
Reading package lists... Done
Building dependency tree... Done
Reading state information... Done
Some packages could not be installed. This may mean that you have
requested an impossible situation or if you are using the unstable
distribution that some required packages have not yet been created
or been moved out of Incoming.
The following information may help to resolve the situation:

The following packages have unmet dependencies:
 chromium : Depends: libdav1d7 (>= 0.1.0) but it is not installable
            Depends: libharfbuzz-subset0 (>= 6.0.0) but it is not installable
E: Unable to correct problems, you have held broken packages.
```
PPA has backported dav1d and harfbuzz for chomium's build, so add the dep pacakges to our repo.