### PR TITLE
enable mesa-vpu extension for other rk3588 csc boards

### DIFF
--- a/userpatches/targets-release-community-maintained.yaml
+++ b/userpatches/targets-release-community-maintained.yaml
@@ -74,7 +74,7 @@ lists:
     # auto generated section
     - { BOARD: aml-s9xx-box, BRANCH: current }
     - { BOARD: aml-t95z-plus, BRANCH: edge }
-    - { BOARD: armsom-aim7-io, BRANCH: vendor }
+    - { BOARD: armsom-aim7-io, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: armsom-sige1, BRANCH: vendor }
     - { BOARD: armsom-sige5, BRANCH: vendor }
     - { BOARD: armsom-sige7, BRANCH: current, ENABLE_EXTENSIONS: "mesa-vpu" }
@@ -82,7 +82,7 @@ lists:
     - { BOARD: bananapim64, BRANCH: current }
     - { BOARD: bananapir2pro, BRANCH: current }
     - { BOARD: clockworkpi-a06, BRANCH: current }
-    - { BOARD: coolpi-cm5, BRANCH: edge }
+    - { BOARD: coolpi-cm5, BRANCH: edge, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: fine3399, BRANCH: current }
     - { BOARD: firefly-itx-3588j, BRANCH: vendor, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
     - { BOARD: firefly-rk3399, BRANCH: current }
@@ -145,7 +145,7 @@ lists:
     - { BOARD: radxa-e25, BRANCH: current }
     - { BOARD: radxa-zero2, BRANCH: current }
     - { BOARD: recore, BRANCH: current }
-    - { BOARD: retro-lite-cm5, BRANCH: vendor }
+    - { BOARD: retro-lite-cm5, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: rk3318-box, BRANCH: current }
     - { BOARD: rk3328-heltec, BRANCH: current }
     - { BOARD: roc-rk3399-pc, BRANCH: current }


### PR DESCRIPTION
To enable panthor for desktop, mesa-vpu is necessary.