### PR TITLE
external: add harfbuzz armhf for multiarch compatibility

### DIFF
--- a/external/chromium-aarch64-jammy.conf
+++ b/external/chromium-aarch64-jammy.conf
@@ -4,6 +4,6 @@ RELEASE=jammy
 TARGET=desktop
 METHOD=aptly
 INSTALL=chromium
-GLOB="Name (% chromium) | Name (% chromium-*) | Name (% libdav1d7) | Name (% libharfbuzz-subset0) | Name (% libharfbuzz0b)"
+GLOB="Name (% chromium) | Name (% chromium-*) | Name (% libdav1d7) | Name (% libharfbuzz-subset0) | Name (% libharfbuzz0b) | Name (% gir1.2-harfbuzz-0.0) | Name (% libharfbuzz-bin) | Name (% libharfbuzz-dev) | Name (% libharfbuzz-gobject0) | Name (% libharfbuzz-icu0)"
 ARCH=arm64
 REPOSITORY=BS

--- a/external/harfbuzz-armhf-jammy.conf
+++ b/external/harfbuzz-armhf-jammy.conf
@@ -1,0 +1,9 @@
+URL="https://ppa.launchpadcontent.net/liujianfeng1994/chromium/ubuntu"
+KEY=jammy
+RELEASE=jammy
+TARGET=desktop
+METHOD=aptly
+INSTALL=libharfbuzz0b
+GLOB="Name (% libharfbuzz-subset0) | Name (% libharfbuzz0b) | Name (% gir1.2-harfbuzz-0.0) | Name (% libharfbuzz-bin) | Name (% libharfbuzz-dev) | Name (% libharfbuzz-gobject0) | Name (% libharfbuzz-icu0)"
+ARCH=armhf
+REPOSITORY=BS


### PR DESCRIPTION
Chromium from ppa https://launchpad.net/~liujianfeng1994/+archive/ubuntu/chromium for jammy introduces backported harfbuzz to armbian's repo. For multiarch compatibility we need to import armhf version of it to armbian.
https://github.com/Botspot/pi-apps/issues/2642