### PR TITLE
Expose mba8mpxl images

### DIFF
--- a/exposed.map
+++ b/exposed.map
@@ -48,6 +48,10 @@ lepotato/archive/Armbian_[0-9].*Lepotato_noble_current_[0-9]*.[0-9]*.[0-9]*_gnom
 lepotato/archive/Armbian_[0-9].*Lepotato_bookworm_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 thinkpad-x13s/archive/Armbian_[0-9].*Thinkpad-x13s_trixie_sc8280xp_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.img.xz
 thinkpad-x13s/archive/Armbian_[0-9].*Thinkpad-x13s_noble_sc8280xp_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.img.xz
+mba8mpxl/archive/Armbian_[0-9].*Mba8mpxl_bookworm_current_[0-9]*.[0-9]*.[0-9]*.img.xz
+mba8mpxl/archive/Armbian_[0-9].*Mba8mpxl_noble_current_[0-9]*.[0-9]*.[0-9]*_xfce_desktop.img.xz
+mba8mpxl-ras314/archive/Armbian_[0-9].*Mba8mpxl-ras314_bookworm_current_[0-9]*.[0-9]*.[0-9]*.img.xz
+mba8mpxl-ras314/archive/Armbian_[0-9].*Mba8mpxl-ras314_noble_current_[0-9]*.[0-9]*.[0-9]*_xfce_desktop.img.xz
 nanopi-r4s/archive/Armbian_[0-9].*Nanopi-r4s_bookworm_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 nanopi-r4s/archive/Armbian_[0-9].*Nanopi-r4s_noble_current_[0-9]*.[0-9]*.[0-9]*.img.xz
 nanopi-r6s/archive/Armbian_[0-9].*Nanopi-r6s_bookworm_vendor_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz


### PR DESCRIPTION
Add regex to expose "bookworm default" and "noble xfce_desktop" for mba8mpxl and mba8mpx-ras314