### PR TITLE
enable mesa-vpu extension for all rk3588 csc boards

### DIFF
--- a/userpatches/targets-release-community-maintained.yaml
+++ b/userpatches/targets-release-community-maintained.yaml
@@ -72,7 +72,7 @@ lists:
     # auto generated section
     - { BOARD: aml-s9xx-box, BRANCH: current }
     - { BOARD: aml-t95z-plus, BRANCH: edge }
-    - { BOARD: armsom-aim7-io, BRANCH: vendor }
+    - { BOARD: armsom-aim7-io, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: armsom-cm5-io, BRANCH: vendor }
     - { BOARD: armsom-cm5-rpi-cm4-io, BRANCH: vendor }
     - { BOARD: armsom-sige1, BRANCH: vendor }
@@ -88,7 +88,7 @@ lists:
     - { BOARD: cm3588-nas, BRANCH: current, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: coolpi-cm5, BRANCH: edge }
     - { BOARD: core3566, BRANCH: vendor }
-    - { BOARD: cyber-aib-rk3588, BRANCH: vendor }
+    - { BOARD: cyber-aib-rk3588, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: fine3399, BRANCH: current }
     - { BOARD: firefly-itx-3588j, BRANCH: vendor, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
     - { BOARD: firefly-rk3399, BRANCH: current }
@@ -133,8 +133,8 @@ lists:
     - { BOARD: orangepi3, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
     - { BOARD: orangepi3b, BRANCH: vendor, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
     - { BOARD: orangepi4, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
-    - { BOARD: orangepi5-max, BRANCH: vendor }
-    - { BOARD: orangepi5pro, BRANCH: vendor }
+    - { BOARD: orangepi5-max, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
+    - { BOARD: orangepi5pro, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: orangepilite2, BRANCH: current }
     - { BOARD: orangepioneplus, BRANCH: current }
     - { BOARD: orangepipc2, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
@@ -155,13 +155,13 @@ lists:
     - { BOARD: radxa-zero2, BRANCH: current }
     - { BOARD: radxa-zero3, BRANCH: vendor }
     - { BOARD: recore, BRANCH: current }
-    - { BOARD: retro-lite-cm5, BRANCH: vendor }
+    - { BOARD: retro-lite-cm5, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: rk3318-box, BRANCH: current }
     - { BOARD: rk3328-heltec, BRANCH: current }
     - { BOARD: roc-rk3399-pc, BRANCH: current }
     - { BOARD: rock-3c, BRANCH: current }
     - { BOARD: rock-4se, BRANCH: current }
-    - { BOARD: rock-5-cm-rpi-cm4-io, BRANCH: vendor }
+    - { BOARD: rock-5-cm-rpi-cm4-io, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: rock-5-cmio, BRANCH: vendor, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
     - { BOARD: rock64, BRANCH: current, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: rockpi-4a, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
@@ -180,7 +180,7 @@ lists:
     - { BOARD: tanix-tx6, BRANCH: current }
     - { BOARD: tinker-edge-r, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
     - { BOARD: tinkerboard-2, BRANCH: current, ENABLE_EXTENSIONS: "v4l2loopback-dkms,mesa-vpu" }
-    - { BOARD: turing-rk1, BRANCH: vendor }
+    - { BOARD: turing-rk1, BRANCH: vendor, ENABLE_EXTENSIONS: "mesa-vpu" }
     - { BOARD: wdk2023, BRANCH: wdk2023}
     - { BOARD: x96-mate, BRANCH: current }
     - { BOARD: x96q, BRANCH: current }


### PR DESCRIPTION
Check all boards with vendor kernel but no mesa-vpu extension:
```
cat userpatches/targets-release-community-maintained.yaml |grep vendor|grep -v mesa-vpu
```
Then enable mesa-vpu on all rk3588 boards.