### PR TITLE
Remove xiaomi-umi from workflow files

### DIFF
--- a/exposed.map
+++ b/exposed.map
@@ -152,8 +152,6 @@ uefi-arm64/archive/Armbian_[0-9].*Uefi-arm64_bookworm_current_[0-9]*.[0-9]*.[0-9
 uefi-arm64/archive/Armbian_[0-9].*Uefi-arm64_noble_current_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.img.xz
 uefi-x86/archive/Armbian_[0-9].*Uefi-x86_bookworm_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 uefi-x86/archive/Armbian_[0-9].*Uefi-x86_noble_current_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.img.xz
-xiaomi-umi/archive/Armbian_[0-9].*Xiaomi-umi_noble_current_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.rootfs.img.xz
-xiaomi-umi/archive/Armbian_[0-9].*Xiaomi-umi_trixie_current_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.rootfs.img.xz
 xiaomi-elish/archive/Armbian_[0-9].*Xiaomi-elish_noble_current_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.rootfs.img.xz
 xiaomi-elish/archive/Armbian_[0-9].*Xiaomi-elish_noble_current_[0-9]*.[0-9]*.[0-9]*_kde-neon_desktop.rootfs.img.xz
 youyeetoo-r1-v3/archive/Armbian_[0-9].*Youyeetoo-r1-v3_noble_vendor_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.img.xz

--- a/userpatches/targets-automation.blacklist
+++ b/userpatches/targets-automation.blacklist
@@ -7,6 +7,5 @@ qemu-uefi-x86
 qemu-uefi-arm64
 thinkpad-x13s
 xiaomi-elish
-xiaomi-umi
 oneplus-kebab
 ayn-odin2

--- a/userpatches/targets-release-standard-support.template
+++ b/userpatches/targets-release-standard-support.template
@@ -138,7 +138,6 @@ targets:
       - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
       - { BOARD: xiaomi-elish, BRANCH: current }
       - { BOARD: oneplus-kebab, BRANCH: current }
-      - { BOARD: xiaomi-umi, BRANCH: current }
       - *standard-support-fast-hdmi
 
   # Full Ubuntu old LTS KDE plasma
@@ -213,7 +212,6 @@ targets:
       # Attention, no list reference here, just a specific board.
       - { BOARD: thinkpad-x13s, BRANCH: sc8280xp }
       - { BOARD: xiaomi-elish, BRANCH: current }
-      - { BOARD: xiaomi-umi, BRANCH: current }
 
   # automated section
   automated-section:


### PR DESCRIPTION
The xiaomi-umi board config has already been removed: https://github.com/armbian/build/commit/5bf962afa07dcecaae3fb5a140a51282a9046d48

As there are still hardcoded references in the standard-support template, the "Build Standard Support Images" workflow stopped working for other boards: https://paste.armbian.com/enebidexuk

The additional references in exposed.map and automation.blacklist are not required as well.

There are still two references in a sed substitution in webindex-update.yml, but I need assistance, how to handle them correctly (see my next PR):
https://github.com/armbian/os/blob/c2959c7a2c1ba61f2b0eb26fa672eb5366771d21/.github/workflows/webindex-update.yml#L162
https://github.com/armbian/os/blob/c2959c7a2c1ba61f2b0eb26fa672eb5366771d21/.github/workflows/webindex-update.yml#L165