### PR TITLE
update mkbootimg from bookworm-backports for noble

### DIFF
--- a/external/mkbootimg-bookworm-backport-to-noble.conf
+++ b/external/mkbootimg-bookworm-backport-to-noble.conf
@@ -1,0 +1,9 @@
+URL=http://deb.debian.org/debian
+KEY="bookworm-backports main"
+RELEASE=noble
+TARGET=utils
+METHOD=aptly
+INSTALL=mkbootimg
+GLOB="Name (% mkbootimg)"
+ARCH=armhf:arm64:amd64
+REPOSITORY=BS


### PR DESCRIPTION
After toggling to noble as default docker env the abl images would fall: https://github.com/armbian/os/actions/runs/15264371095/job/42927451662

We can add mkbootimg from bookworm-backports to noble so this command can work with noble.