### PR TITLE
Update armbian-config tracker in Issue Templates. Closes: #341

### DIFF
--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -19,7 +19,7 @@ contact_links:
     url: https://bugzilla.kernel.org/
     about: If you are using upstream Linux kernel
   - name: Issue with armbian-config
-    url: https://github.com/armbian/config/issues/new
+    url: https://github.com/armbian/configng/issues/new
     about: Utility for configuring your board, adjusting services and installing applications.
   - name: Issue with infrastructure
     url: https://github.com/armbian/mirror/issues/new


### PR DESCRIPTION
armbian-config repo is now named armbian-configng

update the issue templates accordingly