### PR TITLE
add loong64 build support

### DIFF
--- a/userpatches/config-armbian-images.conf
+++ b/userpatches/config-armbian-images.conf
@@ -21,5 +21,6 @@ declare -g KERNEL_CONFIGURE=no
 declare -g PASTE_URL="https://paste.armbian.de/log"
 declare -g DOCKER_ARMBIAN_BASE_IMAGE="ubuntu:jammy"
 [[ $BOARD == bananapif3 ]] && declare -g DOCKER_ARMBIAN_BASE_IMAGE="ubuntu:noble"
+[[ $ARCH == loong64 ]] && declare -g DOCKER_ARMBIAN_BASE_IMAGE="debian:trixie"
 declare -g DONT_BUILD_ARTIFACTS="kernel,firmware,full_firmware,fake_ubuntu_advantage_tools,armbian-zsh,armbian-plymouth-theme"
 declare -g PREFER_DOCKER="yes"

--- a/userpatches/targets-release-standard-support.yaml
+++ b/userpatches/targets-release-standard-support.yaml
@@ -15,10 +15,12 @@ common-gha-configs:
         rootfs-arm64: [ "self-hosted", "Linux", "aarch64" ]
         rootfs-amd64: [ "self-hosted", "Linux", "X64" ]
         rootfs-riscv64: [ "self-hosted", "Linux", "X64" ]
+        rootfs-loong64: [ "self-hosted", "Linux", "aarch64" ]
         image-armhf: [ "self-hosted", "Linux", 'aarch64' ]
         image-arm64: [ "self-hosted", "Linux", 'images' ]
         image-amd64: [ "self-hosted", "Linux", 'images', "X64" ]
         image-riscv64: [ "self-hosted", "Linux", 'images', "X64" ]
+        image-loong64: [ "self-hosted", "Linux", 'images', "aarch64" ]
 
 lists:
 


### PR DESCRIPTION
Loong64 support is added: https://github.com/armbian/build/pull/8419
The build need aarch64 host and trixie docker, hope it can work.