### PR TITLE
use X86 host for loong64 build

### DIFF
--- a/userpatches/targets-release-standard-support.template
+++ b/userpatches/targets-release-standard-support.template
@@ -15,10 +15,12 @@ common-gha-configs:
         rootfs-arm64: [ "self-hosted", "Linux", "aarch64" ]
         rootfs-amd64: [ "self-hosted", "Linux", "X64" ]
         rootfs-riscv64: [ "self-hosted", "Linux", "X64" ]
+        rootfs-loong64: [ "self-hosted", "Linux", "X64" ]
         image-armhf: [ "self-hosted", "Linux", 'aarch64' ]
         image-arm64: [ "self-hosted", "Linux", 'images' ]
         image-amd64: [ "self-hosted", "Linux", 'images', "X64" ]
         image-riscv64: [ "self-hosted", "Linux", 'images', "X64" ]
+        image-loong64: [ "self-hosted", "Linux", 'images', "X64" ]
 
 lists:
 

--- a/userpatches/targets-release-standard-support.yaml
+++ b/userpatches/targets-release-standard-support.yaml
@@ -15,12 +15,12 @@ common-gha-configs:
         rootfs-arm64: [ "self-hosted", "Linux", "aarch64" ]
         rootfs-amd64: [ "self-hosted", "Linux", "X64" ]
         rootfs-riscv64: [ "self-hosted", "Linux", "X64" ]
-        rootfs-loong64: [ "self-hosted", "Linux", "aarch64" ]
+        rootfs-loong64: [ "self-hosted", "Linux", "X64" ]
         image-armhf: [ "self-hosted", "Linux", 'aarch64' ]
         image-arm64: [ "self-hosted", "Linux", 'images' ]
         image-amd64: [ "self-hosted", "Linux", 'images', "X64" ]
         image-riscv64: [ "self-hosted", "Linux", 'images', "X64" ]
-        image-loong64: [ "self-hosted", "Linux", 'images', "aarch64" ]
+        image-loong64: [ "self-hosted", "Linux", 'images', "X64" ]
 
 lists:
 


### PR DESCRIPTION
I find that armbian's X86 host can build rootfs of loong64 while arm64 host doesn't have qemu binfmt support, so use X86 host to build loong64 targets.