### PR TITLE
Update git checkout to use 90 days history

### DIFF
--- a/.github/workflows/changelog-for-all.yml
+++ b/.github/workflows/changelog-for-all.yml
@@ -32,7 +32,7 @@ jobs:
 
           # checkout to 7 days old when we will have 7 days history, now 1
 
-          git checkout $(git log --since=2.days --tags --simplify-by-decoration --pretty="format:%D" | \
+          git checkout $(git log --since=90.days --tags --simplify-by-decoration --pretty="format:%D" | \
           tail -1 | xargs | cut -d" " -f2)
 
           echo 'JSON_CONTENT<<EOF' >> $GITHUB_OUTPUT


### PR DESCRIPTION
Change git checkout command to use a 90-day history instead of 2 days.