### PR TITLE
Fix(live-patch): Correct workflow trigger path

### DIFF
--- a/.github/workflows/live-patch.yml
+++ b/.github/workflows/live-patch.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - 'main'
     paths:
-      - 'live-patch/pre-apt-upgrade.sh'
+      - 'live-patch/**.sh'
       - '.github/workflows/live-patch.yml'
 
 jobs:


### PR DESCRIPTION
The live-patch workflow was configured to trigger on changes to 'live-patch/pre-apt-upgrade.sh', but the actual file is named '01-pre-apt-upgrade.sh'.

This commit changes the path to 'live-patch/**.sh' to correctly trigger the workflow for all shell scripts in the directory.