### PR TITLE
external: drop jammy from desktop multi-release RELEASE lists

### DIFF
--- a/external/chromium-aarch64-jammy.conf
+++ b/external/chromium-aarch64-jammy.conf
@@ -1,9 +1,0 @@
-URL="https://ppa.launchpadcontent.net/liujianfeng1994/chromium/ubuntu"
-KEY=jammy
-RELEASE=jammy
-TARGET=desktop
-METHOD=aptly
-INSTALL=chromium
-GLOB="Name (% chromium) | Name (% chromium-*) | Name (% libdav1d7)"
-ARCH=arm64
-REPOSITORY=BS

--- a/external/code.conf
+++ b/external/code.conf
@@ -1,6 +1,6 @@
 URL=https://packages.microsoft.com/repos/code
 KEY="stable main main"
-RELEASE=jammy:noble:resolute:bookworm:trixie:forky
+RELEASE=noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=code

--- a/external/codium.conf
+++ b/external/codium.conf
@@ -1,6 +1,6 @@
 URL=https://github.com/VSCodium/vscodium
 KEY=main
-RELEASE=jammy:noble:resolute:bookworm:trixie:forky
+RELEASE=noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=gh
 INSTALL=codium

--- a/external/discord.conf
+++ b/external/discord.conf
@@ -1,6 +1,6 @@
 URL=https://discord.com/api/download?platform=linux\&format=deb
 KEY=
-RELEASE=jammy:noble:resolute:bookworm:trixie:forky
+RELEASE=noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=direct
 INSTALL=discord

--- a/external/edge.conf
+++ b/external/edge.conf
@@ -1,6 +1,6 @@
 URL="https://packages.microsoft.com/repos/edge"
 KEY="stable main main"
-RELEASE=jammy:bookworm:noble:resolute:trixie:forky
+RELEASE=bookworm:noble:resolute:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=microsoft-edge-stable

--- a/external/firefox-jammy.conf
+++ b/external/firefox-jammy.conf
@@ -1,9 +1,0 @@
-URL=http://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu
-KEY=jammy
-RELEASE=jammy
-TARGET=desktop
-METHOD=aptly
-INSTALL=firefox
-GLOB="Name (% firefox*), \$Version (>= 146.0)"
-ARCH=armhf:arm64:amd64:riscv64
-REPOSITORY=BS

--- a/external/google-chrome.conf
+++ b/external/google-chrome.conf
@@ -1,6 +1,6 @@
 URL=http://dl.google.com/linux/chrome/deb/
 KEY="stable main"
-RELEASE=jammy:bookworm:noble:resolute:trixie:forky
+RELEASE=bookworm:noble:resolute:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=google-chrome-stable

--- a/external/urbackup-server-jammy.conf
+++ b/external/urbackup-server-jammy.conf
@@ -1,9 +1,0 @@
-URL=https://ppa.launchpadcontent.net/uroni/urbackup/ubuntu
-KEY=jammy
-RELEASE=jammy
-TARGET=utils
-METHOD=aptly
-INSTALL=urbackup-server
-GLOB="Name (% urbackup-server*), \$Version (>= 2.5.30)"
-ARCH=amd64
-REPOSITORY=BS

--- a/external/zoom.conf
+++ b/external/zoom.conf
@@ -1,6 +1,6 @@
 URL="http://mirror.mwt.me/zoom/deb"
 KEY="any"
-RELEASE=jammy:noble:resolute:bookworm:trixie:forky
+RELEASE=noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=zoom


### PR DESCRIPTION
## Summary

jammy (Ubuntu 22.04 LTS) is csc-tier and the desktop story for it is increasingly stale. Drop `jammy:` from the RELEASE list of every desktop multi-release config so the apt.armbian.com mirror set focuses on the supported targets.

| file | before | after |
|---|---|---|
| `code.conf` | `jammy:noble:resolute:bookworm:trixie:forky` | `noble:resolute:bookworm:trixie:forky` |
| `codium.conf` | (same) | (same) |
| `discord.conf` | (same) | (same) |
| `edge.conf` | `jammy:bookworm:noble:resolute:trixie:forky` | `bookworm:noble:resolute:trixie:forky` |
| `google-chrome.conf` | (same) | (same) |
| `zoom.conf` | `jammy:noble:resolute:bookworm:trixie:forky` | `noble:resolute:bookworm:trixie:forky` |

### Out of scope

Utils packages with their own scope, untouched:

- `urbackup-server-jammy.conf`, `zfs-jammy.conf`, `harfbuzz-jammy.conf`, `libcec6-sid-to-jammy.conf`
- `*.conf` files using `KEY=jammy` as a signing-key release name
- `chromium-aarch64-jammy.conf.disabled` — already disabled

## Test plan

- [ ] aptly mirror set rebuilds without jammy snapshots for these 6 sources
- [ ] No regression on noble / resolute / bookworm / trixie / forky desktop builds