### PR TITLE
external: add resolute (Ubuntu 26.04 LTS) to desktop package coverage

### DIFF
--- a/external/chromium-aarch64-resolute.conf
+++ b/external/chromium-aarch64-resolute.conf
@@ -1,0 +1,9 @@
+URL="https://ppa.launchpadcontent.net/xtradeb/apps/ubuntu/"
+KEY=resolute
+RELEASE=resolute
+TARGET=desktop
+METHOD=aptly
+INSTALL=chromium
+GLOB="Name (% chromium) | Name (% chromium-*)"
+ARCH=arm64
+REPOSITORY=BS

--- a/external/code.conf
+++ b/external/code.conf
@@ -1,6 +1,6 @@
 URL=https://packages.microsoft.com/repos/code
 KEY="stable main main"
-RELEASE=noble:bookworm:trixie
+RELEASE=noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=code

--- a/external/codium.conf
+++ b/external/codium.conf
@@ -1,6 +1,6 @@
 URL=https://github.com/VSCodium/vscodium
 KEY=main
-RELEASE=noble:bookworm:trixie
+RELEASE=noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=gh
 INSTALL=codium

--- a/external/discord.conf
+++ b/external/discord.conf
@@ -1,6 +1,6 @@
 URL=https://discord.com/api/download?platform=linux\&format=deb
 KEY=
-RELEASE=noble:bookworm:trixie
+RELEASE=noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=direct
 INSTALL=discord

--- a/external/edge.conf
+++ b/external/edge.conf
@@ -1,6 +1,6 @@
 URL="https://packages.microsoft.com/repos/edge"
 KEY="stable main main"
-RELEASE=bookworm:noble:trixie
+RELEASE=bookworm:noble:resolute:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=microsoft-edge-stable

--- a/external/firefox-resolute.conf
+++ b/external/firefox-resolute.conf
@@ -1,0 +1,9 @@
+URL=http://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu
+KEY=resolute
+RELEASE=resolute
+TARGET=desktop
+METHOD=aptly
+INSTALL=firefox
+GLOB="Name (% firefox*), \$Version (>= 146.0)"
+ARCH=armhf:arm64:amd64:riscv64
+REPOSITORY=BS

--- a/external/google-chrome.conf
+++ b/external/google-chrome.conf
@@ -1,6 +1,6 @@
 URL=http://dl.google.com/linux/chrome/deb/
 KEY="stable main"
-RELEASE=bookworm:noble:trixie
+RELEASE=bookworm:noble:resolute:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=google-chrome-stable

--- a/external/thunderbird-resolute.conf
+++ b/external/thunderbird-resolute.conf
@@ -1,0 +1,9 @@
+URL="http://ppa.launchpadcontent.net/mozillateam/ppa/ubuntu"
+KEY=resolute
+RELEASE=resolute
+TARGET=desktop
+METHOD=aptly
+INSTALL=thunderbird
+GLOB="Name (% thunderbird*), \$Version (>= 147.0)"
+ARCH=armhf:arm64:amd64:riscv64
+REPOSITORY=BS

--- a/external/zoom.conf
+++ b/external/zoom.conf
@@ -1,6 +1,6 @@
 URL="http://mirror.mwt.me/zoom/deb"
 KEY="any"
-RELEASE=noble:bookworm:trixie
+RELEASE=noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=zoom


### PR DESCRIPTION
resolute just promoted to `supported` in armbian/build PR #9657. Mirrors the existing noble desktop sources for the new LTS so the desktop YAML in armbian/configng#848 can rely on apt.armbian.com for chromium / firefox / thunderbird and the vendor desktop apps on resolute.

New per-release files:

  chromium-aarch64-resolute.conf  — xtradeb/apps PPA, arm64
  firefox-resolute.conf            — mozillateam PPA, all 4 arches
  thunderbird-resolute.conf        — mozillateam PPA, all 4 arches

Multi-release RELEASE lists gain `resolute`:

  code.conf, codium.conf
  discord.conf
  edge.conf
  google-chrome.conf
  zoom.conf

Releases skipped on purpose (no apt.armbian.com desktop coverage):

  plucky    — eos as of 2026-01-25
  jammy     — csc; desktop story stale
  questing  — 9-month interim, dropped from configng desktop YAML
  sid       — Debian unstable; vendor debs may break
  loong64   — separate arch story; not yet a desktop target

Out of scope (utils packages with their own scope):
  urbackup-server-*.conf, zfs-*.conf, harfbuzz-jammy.conf,
  libcec6-sid-to-jammy.conf, rpi-*.conf