### PR TITLE
external: consolidate chromium configs + add armhf/amd64 coverage

### DIFF
--- a/external/chromium-noble.conf
+++ b/external/chromium-noble.conf
@@ -1,9 +1,9 @@
 URL="https://ppa.launchpadcontent.net/xtradeb/apps/ubuntu/"
-KEY=resolute
-RELEASE=resolute
+KEY=noble
+RELEASE=noble
 TARGET=desktop
 METHOD=aptly
 INSTALL=chromium
 GLOB="Name (% chromium) | Name (% chromium-*)"
-ARCH=arm64
+ARCH=arm64:armhf:amd64
 REPOSITORY=BS

--- a/external/chromium-resolute.conf
+++ b/external/chromium-resolute.conf
@@ -1,9 +1,9 @@
 URL="https://ppa.launchpadcontent.net/xtradeb/apps/ubuntu/"
-KEY=noble
-RELEASE=noble
+KEY=resolute
+RELEASE=resolute
 TARGET=desktop
 METHOD=aptly
 INSTALL=chromium
 GLOB="Name (% chromium) | Name (% chromium-*)"
-ARCH=arm64
+ARCH=arm64:armhf:amd64
 REPOSITORY=BS

--- a/external/chromium.conf.disabled
+++ b/external/chromium.conf.disabled
@@ -1,9 +1,0 @@
-URL="https://ppa.launchpadcontent.net/xtradeb/apps/ubuntu/"
-KEY=noble
-RELEASE=noble
-TARGET=desktop
-METHOD=aptly
-INSTALL=chromium
-GLOB="Name (% chromium) | Name (% chromium-*)"
-ARCH=armhf:amd64
-REPOSITORY=B


### PR DESCRIPTION
## Summary

xtradeb publishes chromium for `arm64` + `armhf` + `amd64` from the same PPA, so splitting them into per-arch conf files was unnecessary. Consolidate into one file per release covering all three arches via a single multi-arch `ARCH=` field.

### Net coverage gain

| | before | after |
|---|---|---|
| noble | arm64 only | arm64 + armhf + amd64 |
| resolute | arm64 only | arm64 + armhf + amd64 |

Previously `armhf` and `amd64` chromium sat in a long-disabled `chromium.conf.disabled` (noble only, never enabled). This brings real, native `.deb` chromium from apt.armbian.com to **every supported desktop arch on noble + resolute** — so `armbian-config`'s desktop YAML browser slot gets a working chromium across the matrix instead of falling through to the upstream Ubuntu snap-shim.

### Files

| | change |
|---|---|
| `chromium-noble.conf` | renamed from `chromium-aarch64-noble.conf`, `ARCH=arm64:armhf:amd64` |
| `chromium-resolute.conf` | renamed from `chromium-aarch64-resolute.conf`, `ARCH=arm64:armhf:amd64` |
| `chromium.conf.disabled` | removed (superseded by `chromium-noble.conf`) |

## Test plan

- [ ] aptly mirror builds chromium snapshots for arm64 + armhf + amd64 on both noble and resolute
- [ ] On a fresh resolute amd64 desktop install, `apt install chromium` resolves to the apt.armbian.com .deb (not a snap-shim)
- [ ] Same on noble armhf
- [ ] No regression on existing noble arm64 / resolute arm64 chromium installs