### PR TITLE
targets: align with armbian/build desktop-to-armbian-config PR

### DIFF
--- a/userpatches/targets-all-not-eos.yaml
+++ b/userpatches/targets-all-not-eos.yaml
@@ -36,6 +36,7 @@ targets:
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
         desktops: yes # include desktops; 'eos' ones are always skipped
+        tiers: [ minimal, mid, full ] # emit a rootfs per tier (armbian-config module_desktops definitions)
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           arm64: [ { BOARD: "uefi-arm64", BRANCH: "current" } ]
           amd64: [ { BOARD: "uefi-x86", BRANCH: "current" } ]
@@ -57,6 +58,7 @@ targets:
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
         desktops: yes # include desktops; 'eos' ones are always skipped
+        tiers: [ minimal, mid, full ] # emit a rootfs per tier (armbian-config module_desktops definitions)
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           riscv64: [ { BOARD: "uefi-riscv64", BRANCH: "edge" } ]
 
@@ -75,6 +77,7 @@ targets:
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
         desktops: yes # include desktops; 'eos' ones are always skipped
+        tiers: [ minimal, mid, full ] # emit a rootfs per tier (armbian-config module_desktops definitions)
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           loong64: [ { BOARD: "uefi-loong64", BRANCH: "edge" } ]
 
@@ -95,6 +98,7 @@ targets:
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
         desktops: yes # include desktops; 'eos' ones are always skipped
+        tiers: [ minimal, mid, full ] # emit a rootfs per tier (armbian-config module_desktops definitions)
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           armhf:
             - { BOARD: "tinkerboard", BRANCH: "current" }

--- a/userpatches/targets-all-not-eos.yaml
+++ b/userpatches/targets-all-not-eos.yaml
@@ -125,15 +125,17 @@ targets:
       BUILD_MINIMAL: "no"
       BUILD_DESKTOP: "yes"
       DESKTOP_ENVIRONMENT: "xfce"
-      DESKTOP_ENVIRONMENT_CONFIG_NAME: "config_base"
-      DESKTOP_APPGROUPS_SELECTED: "none"
+      DESKTOP_TIER: "mid"
       RELEASE: "noble"
     items-from-inventory:
       #wip: yes # includes all work-in-progress boards
       #all: yes # includes all available BOARD and BRANCH combinations
       #conf: yes # includes all supported boards
       #not-eos: yes # not-eos boards, all branches
-      not-eos-with-video: yes # not-eos boards, all branches, with video out
+      not-eos-with-video: # not-eos boards, all branches, with video out
+        # noble doesn't ship loong64 — uefi-loong64 is covered by the
+        # all-userspace-loong64 group above with its own release set.
+        skip-arches: [ loong64 ]
 
   all-cli:
     enabled: yes
@@ -148,4 +150,6 @@ targets:
       #wip: yes # includes all work-in-progress boards
       #all: yes # includes all available BOARD and BRANCH combinations
       #conf: yes # includes all supported boards
-      not-eos: yes # not-eos boards, all branches
+      not-eos: # not-eos boards, all branches
+        # same loong64 exclusion as all-desktop above
+        skip-arches: [ loong64 ]

--- a/userpatches/targets-all-not-eos.yaml
+++ b/userpatches/targets-all-not-eos.yaml
@@ -35,13 +35,7 @@ targets:
         only-desktops: ["gnome", "xfce", "cinnamon" ] # ONLY include these desktops
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
-        desktops: yes # include desktops, one per desktop_variations below; 'eos' ones are always skipped
-        desktop_variations:
-          - [ ] # empty, no appgroups, simple desktop
-          - [ 3dsupport,browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # 3d + all
-          - [ browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # all except 3d
-          - [ 3dsupport,browsers,email,programming,remote_desktop ] # limited desktop
-          - [ desktop_tools,internet,languages,multimedia,remote_desktop ] # limited desktop
+        desktops: yes # include desktops; 'eos' ones are always skipped
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           arm64: [ { BOARD: "uefi-arm64", BRANCH: "current" } ]
           amd64: [ { BOARD: "uefi-x86", BRANCH: "current" } ]
@@ -62,9 +56,7 @@ targets:
         only-desktops: [ "xfce", "gnome" ] # ONLY include these desktops
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
-        desktops: yes # include desktops, one per desktop_variations below; 'eos' ones are always skipped
-        desktop_variations:
-          - [ ] # empty, no appgroups, simple desktop
+        desktops: yes # include desktops; 'eos' ones are always skipped
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           riscv64: [ { BOARD: "uefi-riscv64", BRANCH: "edge" } ]
 
@@ -82,9 +74,7 @@ targets:
         only-desktops: [ "gnome" ] # ONLY include these desktops
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
-        desktops: yes # include desktops, one per desktop_variations below; 'eos' ones are always skipped
-        desktop_variations:
-          - [ ] # empty, no appgroups, simple desktop
+        desktops: yes # include desktops; 'eos' ones are always skipped
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           loong64: [ { BOARD: "uefi-loong64", BRANCH: "edge" } ]
 
@@ -104,13 +94,7 @@ targets:
         only-desktops: ["xfce"] # ONLY include these desktops
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
-        desktops: yes # include desktops, one per desktop_variations below; 'eos' ones are always skipped
-        desktop_variations:
-          - [ ] # empty, no appgroups, simple desktop
-          - [ 3dsupport,browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # 3d + all
-          - [ browsers,chat,desktop_tools,editors,email,internet,languages,multimedia,office,programming,remote_desktop ] # all except 3d
-          - [ 3dsupport,browsers,email,programming,remote_desktop ] # limited desktop
-          - [ desktop_tools,internet,languages,multimedia,remote_desktop ] # limited desktop
+        desktops: yes # include desktops; 'eos' ones are always skipped
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           armhf:
             - { BOARD: "tinkerboard", BRANCH: "current" }

--- a/userpatches/targets-all-not-eos.yaml
+++ b/userpatches/targets-all-not-eos.yaml
@@ -22,17 +22,17 @@ targets:
   all-userspace:
     configs: [ armbian-images ]
     pipeline:
-      build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "rootfs" ] # only these artifacts
+      build-image: no
+      #only-artifacts: [ "armbian-base-files", "rootfs" ]
       gha: *armbian-gha
     vars: # common vars, must exist.
       USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
     items-from-inventory:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
-        skip-releases: [ "focal", "sid", "oracular", "resolute", "questing" ] # do NOT include these releases
+        skip-releases: [ "questing", "sid"]
         #only-releases: ["trixie", "bookworm", "bullseye"] # ONLY include these releases
         #skip-desktops: [ "lxde" ] # do NOT include these desktops
-        only-desktops: ["gnome", "xfce", "cinnamon" ] # ONLY include these desktops
+        #only-desktops: ["gnome", "xfce", "cinnamon" ] # ONLY include these desktops
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
         desktops: yes # include desktops; 'eos' ones are always skipped
@@ -45,16 +45,16 @@ targets:
     configs: [ armbian-images ]
     pipeline:
       build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "rootfs" ] # only these artifacts
+      #only-artifacts: [ "armbian-base-files", "rootfs" ] # only these artifacts
       gha: *armbian-gha
     vars: # common vars, must exist.
       USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
     items-from-inventory:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
-        #skip-releases: [ "sid" ] # do NOT include these releases
-        only-releases: [ "noble", "trixie", "forky" ] # ONLY include these releases (plucky is EOS)
+        skip-releases: [ "questing", "sid" ] # do NOT include these releases
+        #only-releases: [ "noble", "trixie", "forky" ] # ONLY include these releases (plucky is EOS)
         #skip-desktops: [ "lxde" ] # do NOT include these desktops
-        only-desktops: [ "xfce", "gnome" ] # ONLY include these desktops
+        #only-desktops: [ "xfce", "gnome" ] # ONLY include these desktops
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
         desktops: yes # include desktops; 'eos' ones are always skipped
@@ -73,11 +73,11 @@ targets:
     items-from-inventory:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
         only-releases: [ "sid" ] # sid is the only release that declares loong64 in its architectures
-        only-desktops: [ "gnome" ] # ONLY include these desktops
+        #only-desktops: [ "gnome" ] # ONLY include these desktops
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
         desktops: yes # include desktops; 'eos' ones are always skipped
-        tiers: [ minimal, mid, full ] # emit a rootfs per tier (armbian-config module_desktops definitions)
+        tiers: [ minimal ] # emit a rootfs per tier (armbian-config module_desktops definitions)
         arches: # wanted architectures, and their "example" BOARD and BRANCH.
           loong64: [ { BOARD: "uefi-loong64", BRANCH: "edge" } ]
 
@@ -92,7 +92,7 @@ targets:
     items-from-inventory:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
         #only-releases: ["bookworm"] # ONLY include these releases
-        skip-releases: [ "focal", "sid", "noble", "oracular", "resolute", "questing"]
+        #skip-releases: [ "focal", "sid", "noble", "oracular", "resolute", "questing"]
         #skip-desktops: [ "lxde" ] # do NOT include these desktops
         only-desktops: ["xfce"] # ONLY include these desktops
         cli: yes # include normal CLI userspace

--- a/userpatches/targets-all-not-eos.yaml
+++ b/userpatches/targets-all-not-eos.yaml
@@ -1,6 +1,6 @@
 #
 # This config generates all artefacts except for EOS targets.
-# Also, rootfs/base-files/armbian-desktop for all userspace distros and desktops that are not EOS.
+# Also, rootfs/base-files for all userspace distros and desktops that are not EOS.
 #
 common-gha-configs:
   armbian-gha: &armbian-gha
@@ -23,7 +23,7 @@ targets:
     configs: [ armbian-images ]
     pipeline:
       build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "armbian-desktop", "rootfs" ] # only these artifacts
+      only-artifacts: [ "armbian-base-files", "rootfs" ] # only these artifacts
       gha: *armbian-gha
     vars: # common vars, must exist.
       USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
@@ -50,14 +50,14 @@ targets:
     configs: [ armbian-images ]
     pipeline:
       build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "armbian-desktop", "rootfs" ] # only these artifacts
+      only-artifacts: [ "armbian-base-files", "rootfs" ] # only these artifacts
       gha: *armbian-gha
     vars: # common vars, must exist.
       USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
     items-from-inventory:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
         #skip-releases: [ "sid" ] # do NOT include these releases
-        only-releases: [ "noble", "plucky", "trixie", "forky" ] # ONLY include these releases
+        only-releases: [ "noble", "trixie", "forky" ] # ONLY include these releases (plucky is EOS)
         #skip-desktops: [ "lxde" ] # do NOT include these desktops
         only-desktops: [ "xfce", "gnome" ] # ONLY include these desktops
         cli: yes # include normal CLI userspace
@@ -72,13 +72,13 @@ targets:
     configs: [ armbian-images ]
     pipeline:
       build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "armbian-desktop", "rootfs", "kernel", "uboot" ] # only these artifacts
+      only-artifacts: [ "armbian-base-files", "rootfs", "kernel", "uboot" ] # only these artifacts
       gha: *armbian-gha
     vars: # common vars, must exist.
       USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
     items-from-inventory:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
-        only-releases: [ "forky", "plucky" ] # ONLY include these releases
+        only-releases: [ "sid" ] # sid is the only release that declares loong64 in its architectures
         only-desktops: [ "gnome" ] # ONLY include these desktops
         cli: yes # include normal CLI userspace
         minimal: yes # include minimal CLI userspace
@@ -92,7 +92,7 @@ targets:
     configs: [ armbian-images ]
     pipeline:
       build-image: no # don't build images for this
-      only-artifacts: [ "armbian-base-files", "armbian-desktop", "rootfs" ] # only these artifacts
+      only-artifacts: [ "armbian-base-files", "rootfs" ] # only these artifacts
       gha: *armbian-gha
     vars: # common vars, must exist.
       USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.


### PR DESCRIPTION
## Summary

Aligns `userpatches/targets-all-not-eos.yaml` with the in-flight armbian/build branch `desktop-to-armbian-config`, which rips out the legacy hand-rolled desktop build pipeline and adds a couple of new compositor features (`skip-arches` / `only-arches` filters, board-level ARCH resolution).

## Changes

- **Drop `"armbian-desktop"`** from every `only-artifacts` list (4 places). The artifact + its builder were deleted in armbian/build alongside `config/desktop/`; leaving the string in here means CI tries to build a non-existent artifact.
- **`all-userspace-loong64`**: switch `only-releases` from `[ forky, plucky ]` to `[ sid ]`. `forky` does not declare `loong64` in its architectures; `plucky` is EOS. `sid` is the only release with loong64 support (per `config/distributions/sid/architectures`). Without this change the group emitted zero userspace targets.
- **`all-userspace-riscv64`**: drop EOS `plucky` from `only-releases` (cosmetic — compositor filters it anyway).
- **File header comment**: drop stale `armbian-desktop` mention.
- **`all-desktop` / `all-cli`** (committed earlier on this branch): use the new `items-from-inventory.<key>: { skip-arches: [loong64] }` filter so the noble-hardcoded board matrix stops generating `noble + uefi-loong64` combos that compile.sh rejects downstream; drop the two dead legacy vars (`DESKTOP_ENVIRONMENT_CONFIG_NAME`, `DESKTOP_APPGROUPS_SELECTED`); add explicit `DESKTOP_TIER: mid`.

## Depends on

armbian/build#XXXX (`desktop-to-armbian-config` branch) — the new `skip-arches` filter ships there. Merge order: build-side first, then this.

## Test plan

- [ ] After armbian/build merge, targets-compositor runs against this file cleanly; no "target not supported" skips for loong64 on noble or other invalid arch+release combos
- [ ] `all-userspace-loong64` now emits userspace targets (sid+loong64 for gnome + cli + minimal)
- [ ] `all-userspace-riscv64` build count unchanged (plucky was already silently dropped)
- [ ] No downstream errors about missing `armbian-desktop` artifact