### PR TITLE
external: pull libwidevinecdm0 for noble from liujianfeng1994 rockchip-multimedia PPA

### DIFF
--- a/external/widevine-noble.conf
+++ b/external/widevine-noble.conf
@@ -1,0 +1,9 @@
+URL=https://ppa.launchpadcontent.net/liujianfeng1994/rockchip-multimedia/ubuntu
+KEY=noble
+RELEASE=noble
+TARGET=desktop
+METHOD=aptly
+INSTALL=libwidevinecdm0
+GLOB="Name (% libwidevinecdm0)"
+ARCH=arm64:armhf
+REPOSITORY=BS


### PR DESCRIPTION
## Summary

Adds Widevine CDM — the Chromium content-decryption module used for DRM-protected streams (Netflix, Spotify web, etc.) — to the external download matrix for noble.

`liujianfeng1994`'s `rockchip-multimedia` PPA publishes `libwidevinecdm0 4.10.2662.3+1+noble3` for arm64 and armhf on noble. amd64 isn't built there (desktop amd64 users get Widevine via Google Chrome directly, so no Armbian-mirrored copy is needed).

Ref: https://github.com/armbian/configng/pull/878

## File

`external/widevine-noble.conf`:

```
URL=https://ppa.launchpadcontent.net/liujianfeng1994/rockchip-multimedia/ubuntu
KEY=noble
RELEASE=noble
TARGET=desktop
METHOD=aptly
INSTALL=libwidevinecdm0
GLOB="Name (% libwidevinecdm0)"
ARCH=arm64:armhf
REPOSITORY=BS
```

- `ARCH=arm64:armhf` matches what the PPA actually publishes, so no matrix slot tries to pull a non-existent `.deb`.
- Keyring already ships as `external/keys/liu.gpg` — same PPA owner's `chromium-ubuntu` repo is already consumed via `harfbuzz-jammy.conf` and `unudhcpd.conf`, so no new key needed.
- `KEY=noble` matches the suite name of the PPA (Launchpad PPAs name suites after the Ubuntu release).

## Test plan

- [x] `curl … Packages.gz` against the PPA confirms `libwidevinecdm0 4.10.2662.3+1+noble3` exists for arm64 + armhf on noble, and is NOT built for amd64.
- [ ] Next `Infrastructure: APT repositories update` run with `download_external=true` picks the new conf up and mirrors `libwidevinecdm0` into `debs-beta` / `debs`.
- [ ] Post-sync: `apt-cache policy libwidevinecdm0` on a noble/arm64 Armbian install shows `apt.armbian.com` as a candidate.