### PR TITLE
external: enable code (VSCode) pull for jammy

### DIFF
--- a/external/code.conf
+++ b/external/code.conf
@@ -1,6 +1,6 @@
 URL=https://packages.microsoft.com/repos/code
 KEY="stable main main"
-RELEASE=noble:resolute:bookworm:trixie:forky
+RELEASE=jammy:noble:resolute:bookworm:trixie:forky
 TARGET=desktop
 METHOD=aptly
 INSTALL=code


### PR DESCRIPTION
## Summary

Add \`jammy\` to the RELEASE allow-list in \`external/code.conf\` so the \`code\` (Microsoft VSCode) package gets mirrored into apt.armbian.com's \`jammy-desktop\` component alongside the other five releases it already covers.

## Background

\`packages.microsoft.com/repos/code\` publishes a single \`stable main main\` suite that serves every Debian + Ubuntu release — the apt metadata isn't release-scoped, just arch-scoped (armhf / arm64 / amd64). So from the PPA side there's nothing jammy-specific to configure; the suite + arches stay identical.

On the armbian-config side, the full-tier desktop install on jammy was previously failing with \`E: Unable to locate package code\` because our mirror hadn't ingested it for that release. With this change the next \`Infrastructure: APT repositories update\` run ingests code for jammy and the full-tier install resolves cleanly.

## File

\`external/code.conf\`:

\`\`\`
URL=https://packages.microsoft.com/repos/code
KEY="stable main main"
RELEASE=jammy:noble:resolute:bookworm:trixie:forky   ← added jammy
TARGET=desktop
METHOD=aptly
INSTALL=code
GLOB="Name (% code), \$Version (>= 1.107.0)"
CHECKSUM=ignore
ARCH=armhf:arm64:amd64
REPOSITORY=BS
\`\`\`

## Test plan

- [ ] Next \`Infrastructure: APT repositories update\` run picks this up and mirrors code for jammy armhf/arm64/amd64 into debs-beta/debs.
- [ ] Post-sync: \`apt-cache policy code\` on a jammy/arm64 or jammy/amd64 Armbian install shows apt.armbian.com as a candidate with version ≥ 1.107.0.
- [ ] \`armbian-config --api module_desktops install de=xfce tier=full\` on jammy no longer hits \`E: Unable to locate package code\`.