### PR TITLE
userpatches: skip jammy in items-from-inventory

### DIFF
--- a/userpatches/targets-all-not-eos.yaml
+++ b/userpatches/targets-all-not-eos.yaml
@@ -29,7 +29,7 @@ targets:
       USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
     items-from-inventory:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
-        skip-releases: [ "questing", "sid", "forky"]
+        skip-releases: [ "jammy", "questing", "sid", "forky"]
         #only-releases: ["trixie", "bookworm", "bullseye"] # ONLY include these releases
         #skip-desktops: [ "lxde" ] # do NOT include these desktops
         #only-desktops: ["gnome", "xfce", "cinnamon" ] # ONLY include these desktops
@@ -51,7 +51,7 @@ targets:
       USERSPACE_ONLY: "yes" # this does nothing, but some var must exist. might as well be this.
     items-from-inventory:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
-        skip-releases: [ "forky", "questing", "sid" ] # do NOT include these releases
+        skip-releases: [ "jammy", "forky", "questing", "sid" ] # do NOT include these releases
         #only-releases: [ "noble", "trixie", "forky" ] # ONLY include these releases (plucky is EOS)
         #skip-desktops: [ "lxde" ] # do NOT include these desktops
         #only-desktops: [ "xfce", "gnome" ] # ONLY include these desktops
@@ -74,7 +74,7 @@ targets:
       userspace: # creates items from userspace inventory automatically... 'eos' distributions are always skipped.
         #only-releases: ["bookworm"] # ONLY include these releases
         #skip-releases: [ "focal", "sid", "noble", "oracular", "resolute", "questing"]
-        skip-releases: [ "questing", "sid", "forky"]
+        skip-releases: [ "jammy", "questing", "sid", "forky"]
         #skip-desktops: [ "lxde" ] # do NOT include these desktops
         only-desktops: ["xfce"] # ONLY include these desktops
         cli: yes # include normal CLI userspace
@@ -102,4 +102,4 @@ targets:
       not-eos: # not-eos boards, all branches
         # same loong64 exclusion as all-desktop above
         skip-arches: [ loong64 ]
-        skip-releases: [ sid ]
+        skip-releases: [ sid, jammy ]


### PR DESCRIPTION
## Summary

Add \`jammy\` to the four \`skip-releases\` arrays in [\`userpatches/targets-all-not-eos.yaml\`](userpatches/targets-all-not-eos.yaml). The matrix expansions for \`all-userspace\`, \`all-userspace-riscv64\`, \`all-userspace-armhf\` and \`all-cli\` stop emitting jammy rootfs / image targets.

## Symptom

[Run 25293593837](https://github.com/armbian/os/actions/runs/25293593837) — jammy targets are failing.

## Scope

Only this one file. Other places that reference jammy (templates with \`RELEASE: jammy\` blocks, \`external/*-jammy.conf\` configs, Docker base images, workflow dropdowns) are left alone — those can be a separate cleanup if you want to retire jammy more broadly.

## Diff

\`\`\`diff
-        skip-releases: [ "questing", "sid", "forky"]
+        skip-releases: [ "jammy", "questing", "sid", "forky"]
\`\`\`

(four occurrences across the file).