### PR TITLE
Bump versions: stable 26.5.0, nightly 26.8.0-trunk.1

### DIFF
--- a/nightly.json
+++ b/nightly.json
@@ -1,6 +1,6 @@
 {
   "name": "Armbian OS",
-  "version": "26.2.0-trunk.844",
+  "version": "26.8.0-trunk.1",
   "description": "Linux for ARM development boards",
   "keywords": [
     "ARM",

--- a/stable.json
+++ b/stable.json
@@ -1,6 +1,6 @@
 {
   "name": "Armbian OS",
-  "version": "26.2.5",
+  "version": "26.5.0",
   "description": "Linux for ARM development boards",
   "keywords": [
     "ARM",


### PR DESCRIPTION
| File | Was | Now |
|---|---|---|
| `stable.json`  | `26.2.5`            | `26.5.0`             |
| `nightly.json` | `26.2.0-trunk.844`  | `26.8.0-trunk.1`     |

Opens a new minor on stable (26.2 → 26.5) and resets nightly to a fresh trunk counter targeting 26.8 — well ahead of stable so semver sorts the channels correctly:

```
26.8.0-trunk.1 > 26.5.0      # nightly is ahead of stable, as intended
```