### PR TITLE
gha: don't double-quote board/maintainer filter values

### DIFF
--- a/userpatches/gha/chunks/050.single_header.yaml
+++ b/userpatches/gha/chunks/050.single_header.yaml
@@ -318,11 +318,11 @@ jobs:
           FILTERS="${{ github.event.inputs.targetsFilterInclude }}"
 
           if [ -z "${FILTERS}" ] && [ "${{ github.event.inputs.board }}" != "all" ] && [ -n "${{ github.event.inputs.board }}" ]; then
-              FILTERS='"BOARD:${{ github.event.inputs.board }}"'
+              FILTERS='BOARD:${{ github.event.inputs.board }}'
           fi
 
           if [ -z "${FILTERS}" ] && [ "${{ github.event.inputs.maintainer }}" != "all" ] && [ -n "${{ github.event.inputs.board }}" ]; then
-              FILTERS='"BOARD_MAINTAINERS:${{ github.event.inputs.maintainer }}"'
+              FILTERS='BOARD_MAINTAINERS:${{ github.event.inputs.maintainer }}'
           fi
 
           # this sets outputs "artifact-matrix" #and "image-matrix"


### PR DESCRIPTION
## Summary

The chunk template `userpatches/gha/chunks/050.single_header.yaml` — used by
`recreate-matrix.yml` to (re)generate all `complete-artifact-matrix-*.yml`
workflows — wraps the `inputs.board` and `inputs.maintainer` values in
**literal double quotes** inside single-quoted strings:

```yaml
FILTERS="${{ github.event.inputs.targetsFilterInclude }}"

if [ -z "${FILTERS}" ] && [ "${{ ... .board }}" != "all" ] && [ -n "${{ ... .board }}" ]; then
    FILTERS='"BOARD:${{ github.event.inputs.board }}"'
fi

if [ -z "${FILTERS}" ] && [ "${{ ... .maintainer }}" != "all" ] && [ -n "${{ ... .board }}" ]; then
    FILTERS='"BOARD_MAINTAINERS:${{ github.event.inputs.maintainer }}"'
fi
...
TARGETS_FILTER_INCLUDE="${FILTERS}" \
```

`bash` single quotes preserve content verbatim, so `$FILTERS` ends up as
the literal 8-character string `"BOARD:helios64"` (quotes included). Bash
then substitutes that into the command line as-is, and `compile.sh`
receives a `TARGETS_FILTER_INCLUDE` value whose quotes are *part* of the
string.

`lib/tools/info/targets-compositor.py` splits the filter on `:` and ends
up with `key='"BOARD'` / `value='helios64"'` — no board in inventory
matches that key, and the run fails at `Prepare Info JSON and Matrices`:

```
No invocations left after filtering '{'key': '"BOARD', 'value': 'helios64"'}'!
ERROR: command failed with error code 2
```

## Reproduction

Trigger **Build Standard Support Images (admin)** from Actions and pick
any concrete board from the `board:` combobox (e.g. `helios64`), leave
everything else at defaults → Run workflow.

Fresh failures (both on the same `board:helios64` input):

- run [25888743879](https://github.com/armbian/os/actions/runs/25888743879) → https://paste.armbian.com/kiluqafuvo
- run [25890339566](https://github.com/armbian/os/actions/runs/25890339566) → https://paste.armbian.com/ujasuwuqin

## Fix

Drop the wrapping double quotes — single quotes already preserve the
value verbatim, no escaping is needed:

```diff
- FILTERS='"BOARD:${{ github.event.inputs.board }}"'
+ FILTERS='BOARD:${{ github.event.inputs.board }}'
- FILTERS='"BOARD_MAINTAINERS:${{ github.event.inputs.maintainer }}"'
+ FILTERS='BOARD_MAINTAINERS:${{ github.event.inputs.maintainer }}'
```

Two-line change, single source file. The five generated
`complete-artifact-matrix-*.yml` files will pick up the fix on the next
`recreate-matrix.yml` run (manual dispatch or the existing `cron: 00 5 * * *`
schedule).

## Notes

- Not a recent regression — last commit touching the source chunk is
  `0460037` (2026-03-15, "Update actions"); it did not change these lines.
  The bug has been latent since the `board:` / `maintainer:` combobox
  inputs were introduced. Most users probably feed `targetsFilterInclude`
  directly and never hit this path.
- Workaround until merged: leave `board=all` (and `maintainer=all`) in the
  form, and set `targetsFilterInclude=BOARD:<board>` directly — that
  input flows into `FILTERS` via line 318 (`FILTERS="${{ ...
  .targetsFilterInclude }}"`), which is not wrapped in extra quotes.

## Test plan

- [ ] After merge, dispatch `recreate-matrix.yml` (or wait for cron).
- [ ] Confirm regenerated `.github/workflows/complete-artifact-matrix-*.yml`
      files contain `FILTERS='BOARD:${{ ... }}'` (no inner quotes).
- [ ] Re-dispatch `Build Standard Support Images (admin)` with
      `board=helios64`, confirm the `Prepare Info JSON and Matrices` step
      passes and the matrix is non-empty.