### PR TITLE
zfs-bookworm: pull from trixie for libzfs7 / libzpool7

### DIFF
--- a/external/zfs-bookworm.conf
+++ b/external/zfs-bookworm.conf
@@ -1,5 +1,5 @@
 URL=http://deb.debian.org/debian
-KEY="forky contrib non-free"
+KEY="trixie contrib non-free"
 RELEASE=bookworm
 TARGET=utils
 METHOD=aptly

--- a/external/zfs-bookworm.conf
+++ b/external/zfs-bookworm.conf
@@ -1,5 +1,5 @@
 URL=http://deb.debian.org/debian
-KEY="bookworm-backports contrib non-free"
+KEY="forky contrib non-free"
 RELEASE=bookworm
 TARGET=utils
 METHOD=aptly

--- a/external/zfs-bookworm.conf
+++ b/external/zfs-bookworm.conf
@@ -4,6 +4,6 @@ RELEASE=bookworm
 TARGET=utils
 METHOD=aptly
 INSTALL="zfs-dkms zfsutils-linux"
-GLOB="Name (% zfsutils-linux) | Name (% libnvpair3linux) | Name (% libzfs6linux) | Name (% libzpool6linux) | Name (% libuutil3linux) | Name (% zfs-dkms) | Name (% zfs-zed)"
+GLOB="Name (% zfsutils-linux) | Name (% libnvpair3linux) | Name (% libzfs7linux) | Name (% libzpool7linux) | Name (% libuutil3linux) | Name (% zfs-dkms) | Name (% zfs-zed)"
 ARCH=armhf:arm64:amd64
 REPOSITORY=BS


### PR DESCRIPTION
## Summary
Bump \`external/zfs-bookworm.conf\` to track newer ZFS by pulling from the next-release suite:

\`\`\`diff
-KEY=\"bookworm-backports contrib non-free\"
+KEY=\"trixie contrib non-free\"
-GLOB=\"... | Name (% libzfs6linux) | Name (% libzpool6linux) | ...\"
+GLOB=\"... | Name (% libzfs7linux) | Name (% libzpool7linux) | ...\"
\`\`\`

Result: bookworm picks up the libzfs7 / libzpool7 ABI line.

## Why trixie and not forky
First attempt was \`forky\` (matching the trixie config), but the forky build of \`zfs-dkms\` requires \`dkms (>= 3.0.11)\` which bookworm's apt set can't satisfy — install bails with \`held broken packages\`. Trixie's \`zfs-dkms\` requires a lower dkms version that bookworm can install, while still bringing the libzfs7 ABI.

So:
- bookworm → pulls from **trixie** (this PR).
- trixie   → pulls from **forky** (already in [\`external/zfs-trixie.conf\`](external/zfs-trixie.conf)).

Each release tracks one suite ahead.

## Test plan
- [ ] Re-sync the aptly BS mirror against the new \`trixie\` suite.
- [ ] Confirm \`libzfs7linux\` / \`libzpool7linux\` / \`zfs-dkms\` are present.
- [ ] Build a bookworm image with ZFS enabled; confirm \`zfs --version\` and that apt install succeeds without unmet-dependency errors.