### PR TITLE
Add tq-smarc2-tqma8mpxs and mba93xxla-mini board support

### DIFF
--- a/exposed.map
+++ b/exposed.map
@@ -76,6 +76,8 @@ mba8mpxl/archive/Armbian_[0-9].*Mba8mpxl_trixie_current_[0-9]*.[0-9]*.[0-9]*_min
 mba8mpxl/archive/Armbian_[0-9].*Mba8mpxl_noble_current_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.img.xz
 mba8mpxl-ras314/archive/Armbian_[0-9].*Mba8mpxl-ras314_trixie_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 mba8mpxl-ras314/archive/Armbian_[0-9].*Mba8mpxl-ras314_noble_current_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.img.xz
+mba93xxla-mini/archive/Armbian_[0-9].*Mba93xxla-mini_trixie_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
+mba93xxla-mini/archive/Armbian_[0-9].*Mba93xxla-mini_noble_current_[0-9]*.[0-9]*.[0-9]*_xfce_desktop.img.xz
 nanopi-r3s-lts/archive/Armbian_[0-9].*Nanopi-r3s-lts_trixie_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 nanopi-r3s-lts/archive/Armbian_[0-9].*Nanopi-r3s-lts_noble_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 nanopi-r4s/archive/Armbian_[0-9].*Nanopi-r4s_trixie_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
@@ -194,6 +196,8 @@ tinkerboard/archive/Armbian_[0-9].*Tinkerboard_bookworm_current_[0-9]*.[0-9]*.[0
 tinkerboard/archive/Armbian_[0-9].*Tinkerboard_noble_current_[0-9]*.[0-9]*.[0-9]*_xfce_desktop.img.xz
 tmds62levm/archive/Armbian_[0-9].*Tmds62levm_bookworm_vendor_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 tmds62levm/archive/Armbian_[0-9].*Tmds62levm_noble_vendor_[0-9]*.[0-9]*.[0-9]*.img.xz
+tq-smarc2-tqma8mpxs/archive/Armbian_[0-9].*Tq-smarc2-tqma8mpxs_trixie_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
+tq-smarc2-tqma8mpxs/archive/Armbian_[0-9].*Tq-smarc2-tqma8mpxs_noble_current_[0-9]*.[0-9]*.[0-9]*_gnome_desktop.img.xz
 tritium-h3/archive/Armbian_[0-9].*Tritium-h3_noble_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 tritium-h3/archive/Armbian_[0-9].*Tritium-h3_bookworm_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 tritium-h5/archive/Armbian_[0-9].*Tritium-h5_bookworm_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz

--- a/userpatches/targets-automation-nightly.blacklist
+++ b/userpatches/targets-automation-nightly.blacklist
@@ -19,12 +19,14 @@ lafrite
 lepotato
 mba8mpxl
 mba8mpxl-ras314
+mba93xxla-mini
 odroidc2
 olimex-teres-a64
 onecloud
 pine64
 radxa-zero
 renegade
+tq-smarc2-tqma8mpxs
 tritium-h3
 tritium-h5
 uefi-arm64

--- a/userpatches/targets-automation.blacklist
+++ b/userpatches/targets-automation.blacklist
@@ -11,6 +11,7 @@ oneplus-kebab
 ayn-odin2
 mekotronics-r58hd
 mekotronics-r58-4x4
+mba93xxla-mini
 retroidpocket-rp5
 retroidpocket-rpmini
 orangepi5-ultra

--- a/userpatches/targets-release-standard-support.template
+++ b/userpatches/targets-release-standard-support.template
@@ -45,6 +45,7 @@ targets:
       - *standard-support-fast-hdmi
       - *standard-support-headless
       - *standard-support-riscv64
+      - { BOARD: mba93xxla-mini, BRANCH: current }
 
   # Debian sid minimal
   minimal-cli-sid-debian:
@@ -117,6 +118,7 @@ targets:
       - *standard-support-riscv64
       - { BOARD: mekotronics-r58hd, BRANCH: vendor }
       - { BOARD: mekotronics-r58-4x4, BRANCH: vendor }
+      - { BOARD: mba93xxla-mini, BRANCH: current }
 
   # Ubuntu full CLI
   full-cli-stable-ubuntu:
@@ -154,6 +156,7 @@ targets:
     items:
       - *standard-support-slow-hdmi
       - *standard-support-fast-hdmi
+      - { BOARD: mba93xxla-mini, BRANCH: current }
 
   # Full Debian stable XFCE
   xfce-desktop-stable-debian:
@@ -173,6 +176,7 @@ targets:
       - *standard-support-slow-hdmi
       - { BOARD: mekotronics-r58hd, BRANCH: vendor }
       - { BOARD: mekotronics-r58-4x4, BRANCH: vendor }
+      - { BOARD: mba93xxla-mini, BRANCH: current }
 
   # Full Ubuntu Gnome
   gnome-3d-desktop-lts-ubuntu:


### PR DESCRIPTION
- Exclude both new boards from nightly automation blacklist
- Exclude mba93xxla-mini from standard automation (no OpenGL GPU)
- Add mba93xxla-mini explicitly to CLI and XFCE targets only, omitting GNOME and Cinnamon which require OpenGL
- Add exposed.map entries for both boards