### PR TITLE
gha: add retry and empty-result guard to NetBox server list step

### DIFF
--- a/userpatches/gha/chunks/050.single_header.yaml
+++ b/userpatches/gha/chunks/050.single_header.yaml
@@ -412,11 +412,26 @@ jobs:
 
             echo "Generating $outfile from $url"
 
-            timeout 10 curl -s \
+            # Fetch with retries; curl handles transient failures itself.
+            # --retry-all-errors covers connection timeouts as well as 5xx.
+            response="$(curl -s --fail \
+              --connect-timeout 10 --max-time 30 \
+              --retry 5 --retry-delay 2 --retry-all-errors \
               -H "Authorization: Token ${{ secrets.NETBOX_TOKEN }}" \
               -H "Accept: application/json; indent=4" \
-              "$url" \
-            | jq "$JQ_FILTER" > "$outfile"
+              "$url")"
+
+            echo "$response" | jq "$JQ_FILTER" > "$outfile"
+
+            # Guard against a valid-but-empty result set: NetBox returning no
+            # matching VMs would otherwise produce an empty server list and let
+            # the build proceed with nowhere to upload/download from.
+            count="$(jq 'length' "$outfile")"
+            if [ "$count" -eq 0 ]; then
+              echo "::error::$outfile is empty (NetBox returned no '$kind' servers from $url)"
+              exit 1
+            fi
+            echo "  -> $count server(s)"
 
           done
 


### PR DESCRIPTION
## What

Hardens the **Generate server lists from NetBox** step in `userpatches/gha/chunks/050.single_header.yaml`.

- **Retry:** replaces the blunt `timeout 10 curl -s` wrapper with curl's own retry logic — `--retry 5 --retry-delay 2 --retry-all-errors` plus `--connect-timeout 10 --max-time 30` and `--fail`. Transient NetBox/network hiccups no longer abort the build on first failure, and HTTP 4xx/5xx now trigger retries instead of writing an error body.
- **Empty-result guard:** fails the step (with a `::error::` annotation and per-file server count) when NetBox returns a valid-but-empty result set, instead of silently writing an empty server list and letting the build proceed with nowhere to upload/download from.

## Why

Previously a momentary slow NetBox response (10s is tight for `limit=500`) would kill the whole build with no retry, and a `{"results": []}` response would slip through silently and surface as a confusing failure much later in the pipeline.

## Not addressed (need maintainer intent)

- `servers` and `servers-download` produce byte-for-byte identical files — left as-is.
- `servers-upload` uses `&tag=upload&tag=images` (AND semantics) — left as-is pending confirmation it's intended.