### PR TITLE
gha/chunks: export per-runner apt/ghcr/ccache env from runner registry

### DIFF
--- a/userpatches/gha/chunks/550.per-chunk-artifacts_job.yaml
+++ b/userpatches/gha/chunks/550.per-chunk-artifacts_job.yaml
@@ -60,6 +60,23 @@ jobs: # <TEMPLATE-IGNORE>
           sudo ./compile.sh requirements
           sudo chown -R "$(id -u):$(id -g)" .
 
+      - name: "Runner info for ${{ runner.name }}"
+        run: |
+          info="$(curl -fsSL "https://github.armbian.com/servers/github-runners.jq" \
+            | jq --arg name "${{ runner.name }}" '
+                ($name | sub("-[0-9]+$"; "")) as $base
+                | first(.[] | select((.host | split(".")[0]) == $base)) // {}
+              ')"
+          echo "Runner info for ${{ runner.name }}:"
+          echo "$info"
+          echo "--- Exported environment ---"
+          for map in apt_proxy:APT_PROXY_ADDR oci_cache:GHCR_MIRROR_ADDRESS redis_cache:CCACHE_REMOTE_STORAGE; do
+            key="${map%%:*}"; var="${map##*:}"
+            value="$(jq -r --arg k "$key" '.[$k] // ""' <<< "$info")"
+            echo "${var}=${value}"
+            echo "${var}=${value}" >> "$GITHUB_ENV"
+          done
+
       - name: Build  ${{matrix.desc}}
         timeout-minutes: 90
         id: build


### PR DESCRIPTION
## Summary

Adds a step to the per-chunk artifacts job that looks up the current runner in `github-runners.jq` and exports its caches into the build environment for later use by `compile.sh`.

Matching: the host's first dot-label is compared against `runner.name` with its instance suffix (`-NN`) stripped (e.g. `ampere-1-01` → `ampere-1`, matches host `ampere-1` or `ampere-1.domain`).

Exported variables:

| registry key  | env var                 |
|---------------|-------------------------|
| `apt_proxy`   | `APT_PROXY_ADDR`        |
| `oci_cache`   | `GHCR_MIRROR_ADDRESS`   |
| `redis_cache` | `CCACHE_REMOTE_STORAGE` |

Values are also echoed to the log for debugging. Hosts with empty/missing fields export blank values without error.