### PR TITLE
gha/chunks: export per-runner caches in images job

### DIFF
--- a/userpatches/gha/chunks/650.per-chunk-images_job.yaml
+++ b/userpatches/gha/chunks/650.per-chunk-images_job.yaml
@@ -69,6 +69,23 @@ jobs: # <TEMPLATE-IGNORE>
         run: |
           rm -f userpatches/VERSION
 
+      - name: "Runner info for ${{ runner.name }}"
+        run: |
+          info="$(curl -fsSL "https://github.armbian.com/servers/github-runners.jq" \
+            | jq --arg name "${{ runner.name }}" '
+                ($name | sub("-[0-9]+$"; "")) as $base
+                | first(.[] | select((.host | split(".")[0]) == $base)) // {}
+              ')"
+          echo "Runner info for ${{ runner.name }}:"
+          echo "$info"
+          echo "--- Exported environment ---"
+          for map in apt_proxy:APT_PROXY_ADDR oci_cache:GHCR_MIRROR_ADDRESS redis_cache:CCACHE_REMOTE_STORAGE; do
+            key="${map%%:*}"; var="${map##*:}"
+            value="$(jq -r --arg k "$key" '.[$k] // ""' <<< "$info")"
+            echo "${var}=${value}"
+            echo "${var}=${value}" >> "$GITHUB_ENV"
+          done
+
       - name: ${{matrix.desc}}
         id: build-one-image
         timeout-minutes: 90


### PR DESCRIPTION
## Summary

Applies the same runner-registry lookup (added for the artifacts job in #471) to the **per-chunk images** template. Before the image build, it looks up the current runner in `github-runners.jq` and exports its caches into the build environment.

Matching: the host's first dot-label is compared against `runner.name` with its instance suffix (`-NN`) stripped (e.g. `ampere-1-01` → `ampere-1`).

Exported variables:

| registry key  | env var                 |
|---------------|-------------------------|
| `apt_proxy`   | `APT_PROXY_ADDR`        |
| `oci_cache`   | `GHCR_MIRROR_ADDRESS`   |
| `redis_cache` | `CCACHE_REMOTE_STORAGE` |

Values are echoed to the log for debugging. Hosts with empty/missing fields export blank values without error.

Companion to #471 (artifacts job).