### PR TITLE
gha: add ssh/rsync timeouts to image upload so dead servers fail fast

### DIFF
--- a/userpatches/gha/chunks/650.per-chunk-images_job.yaml
+++ b/userpatches/gha/chunks/650.per-chunk-images_job.yaml
@@ -365,8 +365,14 @@ jobs: # <TEMPLATE-IGNORE>
                   for attempt in $(seq 1 "$max_retries"); do
                       echo "[$SERVER_URL] rsync attempt ${attempt}/${max_retries}..."
 
+                      # Timeouts so an unreachable/stalled server fails fast
+                      # instead of hanging the whole attempt:
+                      #   ssh ConnectTimeout    - cap the TCP connect (unreachable host)
+                      #   ssh ServerAlive*      - drop a dead connection mid-transfer (~60s)
+                      #   rsync --timeout       - abort if no data moves for 300s
                       if rsync --progress \
-                          -e "ssh -p ${SERVER_PORT} -o StrictHostKeyChecking=accept-new" \
+                          --timeout=300 \
+                          -e "ssh -p ${SERVER_PORT} -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=4" \
                           -rvP \
                           "${RSYNC_FILTER[@]}" \
                           output/images/ \


### PR DESCRIPTION
## Problem

In the per-chunk image job (`userpatches/gha/chunks/650.per-chunk-images_job.yaml`), the "Upload to servers" rsync had **no connect timeout**. If a mirror is unreachable, ssh grinds through TCP SYN retries (often 1–3 minutes) before failing — for *each* of the 3 attempts — so a single dead server stalls the upload step for many minutes.

## Fix

Add timeouts to the rsync/ssh transport:

```diff
  if rsync --progress \
+     --timeout=300 \
-     -e "ssh -p ${SERVER_PORT} -o StrictHostKeyChecking=accept-new" \
+     -e "ssh -p ${SERVER_PORT} -o StrictHostKeyChecking=accept-new -o ConnectTimeout=15 -o ServerAliveInterval=15 -o ServerAliveCountMax=4" \
      -rvP "${RSYNC_FILTER[@]}" \
      output/images/ \
      "${SERVER_USERNAME}@${SERVER_URL}:${SERVER_PATH}/${REMOTE_SUBDIR}"
```

- **`ConnectTimeout=15`** — caps the TCP connect; unreachable host errors in ~15 s instead of minutes. (`rsync --contimeout` doesn't help here — it's rsync-daemon only, not the ssh transport.)
- **`ServerAliveInterval=15` + `ServerAliveCountMax=4`** — drops a connection that dies mid-transfer after ~60 s.
- **`rsync --timeout=300`** — backstop for stalled I/O.

With `max_retries=3` and the 10 s back-off, a dead server now costs ~75 s before the step fails, instead of potentially many minutes per attempt.

The local `rsync -av` copies (userpatches/release-targets) are untouched — no ssh/network, can't hang.

This is a template chunk, so it propagates when the workflows are regenerated.