### PR TITLE
config: build and expose q8b UFS images on the debian:trixie base

### DIFF
--- a/exposed.map
+++ b/exposed.map
@@ -162,6 +162,8 @@ rock-5-itx/archive/Armbian_[0-9].*Rock-5-itx_noble_vendor_[0-9]*.[0-9]*.[0-9]*_g
 rock-5-itx/archive/Armbian_[0-9].*Rock-5-itx_trixie_vendor_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 radxa-dragon-q6a/Armbian_[0-9].*Radxa-dragon-q6a_noble_edge_[0-9]*.[0-9]*.[0-9](-rc[0-9]+)?*_gnome_desktop.img.xz
 radxa-dragon-q6a/Armbian_[0-9].*Radxa-dragon-q6a_trixie_edge_[0-9]*.[0-9]*.[0-9](-rc[0-9]+)?*_minimal.img.xz
+radxa-dragon-q8b/Armbian_[0-9].*Radxa-dragon-q8b_noble_vendor_[0-9]*.[0-9]*.[0-9](-rc[0-9]+)?*_gnome_desktop.img.xz
+radxa-dragon-q8b/Armbian_[0-9].*Radxa-dragon-q8b_trixie_vendor_[0-9]*.[0-9]*.[0-9](-rc[0-9]+)?*_minimal.img.xz
 radxa-zero/archive/Armbian_[0-9].*Radxa-zero_bookworm_current_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz
 radxa-zero/archive/Armbian_[0-9].*Radxa-zero_noble_current_[0-9]*.[0-9]*.[0-9]*.img.xz
 radxa-zero3/archive/Armbian_[0-9].*Radxa-zero3_bookworm_vendor_[0-9]*.[0-9]*.[0-9]*_minimal.img.xz

--- a/userpatches/config-armbian-images.conf
+++ b/userpatches/config-armbian-images.conf
@@ -25,7 +25,7 @@ declare -g EXPERT="yes"
 declare -g KERNEL_CONFIGURE=no
 
 case "$BOARD" in
-    uefi-loong64|radxa-nio-12l|radxa-dragon-q6a|qcom-robotics-rb5|uefi-arm64-dt)
+    uefi-loong64|radxa-nio-12l|radxa-dragon-q6a|radxa-dragon-q8b|qcom-robotics-rb5|uefi-arm64-dt)
         DOCKER_ARMBIAN_BASE_IMAGE="debian:trixie"
         ;;
     *)


### PR DESCRIPTION
The Radxa Dragon Q8B enables the ufs extension for its UFS-module image variant, which needs sfdisk >= 2.41 from util-linux.

The default build container (ubuntu:noble) ships an older sfdisk, so add radxa-dragon-q8b to the debian:trixie board list in config-armbian-images.conf, matching radxa-dragon-q6a and the other UFS boards. Standard-support and nightly both build q8b via the armbian-images config, so only that file needs it.

Also add q8b to exposed.map so its noble gnome and trixie minimal images are featured in the web download index, mirroring the radxa-dragon-q6a entries.

This pairs with the release-targets change (armbian.github.io) that enables the ufs extension for q8b.
