### PR TITLE
config: drop radxa-dragon-q6a from apps and community trixie base

### DIFF
--- a/userpatches/config-armbian-apps.conf
+++ b/userpatches/config-armbian-apps.conf
@@ -22,7 +22,7 @@ declare -g BSPFREEZE="yes"
 declare -g DONT_BUILD_ARTIFACTS="kernel,firmware,full_firmware,fake_ubuntu_advantage_tools,armbian-config,armbian-zsh,armbian-plymouth-theme"
 
 case "$BOARD" in
-    uefi-loong64|radxa-nio-12l|radxa-dragon-q6a|qcom-robotics-rb5)
+    uefi-loong64|radxa-nio-12l|qcom-robotics-rb5)
         DOCKER_ARMBIAN_BASE_IMAGE="debian:trixie"
         ;;
     panther-x2|udoo|armsom-sige3|armsom-sige5|armsom-sige7|dshanpi-a1|firefly-itx-3588j|rock-3a|rock-5c|mixtile-blade3|rock-2f|bananapim7|rockpi-s|clearfogpro|helios4|cubox-i)

--- a/userpatches/config-armbian-community.conf
+++ b/userpatches/config-armbian-community.conf
@@ -25,7 +25,7 @@ declare -g KERNEL_CONFIGURE=no
 declare -g DONT_BUILD_ARTIFACTS="kernel,firmware,full_firmware,fake_ubuntu_advantage_tools,armbian-config,armbian-zsh,armbian-plymouth-theme"
 
 case "$BOARD" in
-    uefi-loong64|radxa-nio-12l|radxa-dragon-q6a|qcom-robotics-rb5)
+    uefi-loong64|radxa-nio-12l|qcom-robotics-rb5)
         DOCKER_ARMBIAN_BASE_IMAGE="debian:trixie"
         ;;
     panther-x2|udoo|armsom-sige3|armsom-sige5|armsom-sige7|dshanpi-a1|firefly-itx-3588j|rock-3a|rock-5c|mixtile-blade3|rock-2f|bananapim7|rockpi-s|clearfogpro|helios4|cubox-i|avaota-a1)


### PR DESCRIPTION
The Radxa Dragon Q6A only ships release images through the standard-support pipeline (configs: armbian-images). It is not present in the application-images list (targets-release-apps.yaml) or the community-maintained target lists.

Its debian:trixie override in config-armbian-apps.conf and config-armbian-community.conf is therefore never evaluated for this board, so drop it. The active entry stays in config-armbian-images.conf, which is the config both standard-support and nightly use to build q6a.

This is a cleanup of the over-inclusion added when the UFS boards were first wired up.
