### PR TITLE
gha: disable build cronjobs (moved to armbian/ci)

### DIFF
--- a/.github/workflows/complete-artifact-matrix-all-stable.yml
+++ b/.github/workflows/complete-artifact-matrix-all-stable.yml
@@ -4,8 +4,6 @@
 name: "Build All Stable Artifacts (cronjob)"
 
 on:
-  schedule:
-   - cron: '0 2 * * *'
   workflow_call:
     inputs:
       ref:                      # commit id

--- a/.github/workflows/complete-artifact-matrix-all.yml
+++ b/.github/workflows/complete-artifact-matrix-all.yml
@@ -4,9 +4,6 @@
 name: "Build All Artifacts (cronjob)"
 
 on:
-  schedule:
-   - cron: '0 20-23/2,0-4/2 * * *'
-   - cron: '0 8,14 * * *'
   workflow_call:
     inputs:
       ref:                      # commit id

--- a/.github/workflows/complete-artifact-matrix-community-maintained.yml
+++ b/.github/workflows/complete-artifact-matrix-community-maintained.yml
@@ -4,9 +4,6 @@
 name: "Build Community Images (cronjob)"
 
 on:
-  schedule:
-   - cron: '0 23 * * THU'
-
   workflow_call:
     inputs:
       ref:                      # commit id

--- a/.github/workflows/complete-artifact-matrix-nightly.yml
+++ b/.github/workflows/complete-artifact-matrix-nightly.yml
@@ -4,13 +4,6 @@
 name: "Build Nightly Images (cronjob)"
 
 on:
-  schedule:
-   - cron: '30 22 * * *'
-  push:
-    branches:
-      - 'main'
-    paths:
-      - 'userpatches/targets-release-nightly.yaml'
   workflow_call:
     inputs:
       ref:                      # commit id

--- a/userpatches/gha/gha_config_all.yaml
+++ b/userpatches/gha/gha_config_all.yaml
@@ -29,4 +29,4 @@ userpatches_config_for_prepare_job: "armbian-images" # use "" for no config file
 repository_runner: "[ repository ]"
 
 # when this should run
-cron_job: "schedule:\n   - cron: '0 20-23/2,0-4/2 * * *'\n   - cron: '0 8,14 * * *'"
+cron_job: ""  # cronjob moved to armbian/ci (os being deprecated)

--- a/userpatches/gha/gha_config_all_stable.yaml
+++ b/userpatches/gha/gha_config_all_stable.yaml
@@ -29,4 +29,4 @@ userpatches_config_for_prepare_job: "armbian-images" # use "" for no config file
 repository_runner: "[ repository ]"
 
 # when this should run
-cron_job: "schedule:\n   - cron: '0 2 * * *'"
+cron_job: ""  # cronjob moved to armbian/ci (os being deprecated)

--- a/userpatches/gha/gha_config_nightly.yaml
+++ b/userpatches/gha/gha_config_nightly.yaml
@@ -30,4 +30,4 @@ userpatches_config_for_prepare_job: "armbian-images" # use "" for no config file
 repository_runner: "[ repository ]"
 
 # when this should run
-cron_job: "schedule:\n   - cron: '30 22 * * *'\n  push:\n    branches:\n      - 'main'\n    paths:\n      - 'userpatches/targets-release-nightly.yaml'"
+cron_job: ""  # cronjob moved to armbian/ci (os being deprecated)

--- a/userpatches/gha/gha_config_release_community_maintained.yaml
+++ b/userpatches/gha/gha_config_release_community_maintained.yaml
@@ -29,4 +29,4 @@ userpatches_config_for_prepare_job: "armbian-community" # use "" for no config f
 repository_runner: "[ repository ]"
 
 # when this should run
-cron_job: "schedule:\n   - cron: '0 23 * * THU'\n"
+cron_job: ""  # cronjob moved to armbian/ci (os being deprecated)


### PR DESCRIPTION
Part of deprecating **armbian/os**: hand the four scheduled builds to **armbian/ci**.

Sets `cron_job: ""` in the four build-target `userpatches/gha/gha_config_*.yaml` (source of truth) and strips the matching `schedule:`/`push:` from the generated `complete-artifact-matrix-*.yml` so it takes effect on merge (recreate-matrix reproduces the same output from the config).

Disabled here → enabled in ci:
| target | cron |
|---|---|
| nightly | `30 22 * * *` |
| all | `0 20-23/2,0-4/2 * * *` + `0 8,14 * * *` |
| all-stable | `0 2 * * *` |
| community | `0 23 * * THU` |

Non-build crons (repository-sync, delete-old-releases, watchdog, redirector-update, …) are untouched.

⚠️ **Merge together with armbian/ci#(enable) — same time**, so there's no gap or double-build.