### PR TITLE
external: add arm64 to google-chrome

### DIFF
--- a/external/google-chrome.conf
+++ b/external/google-chrome.conf
@@ -5,5 +5,5 @@ TARGET=desktop
 METHOD=aptly
 INSTALL=google-chrome-stable
 GLOB="Name (% google-chrome-stable), \$Version (>= 124.0)"
-ARCH=amd64
+ARCH=amd64:arm64
 REPOSITORY=BS


### PR DESCRIPTION
## What

Adds **arm64** to the `google-chrome` external repo mirror — `ARCH=amd64` → `ARCH=amd64:arm64`.

## Why

Google **now publishes `google-chrome-stable` for arm64** alongside amd64 in its apt repo (`dl.google.com/linux/chrome/deb`). Verified against the live repo:

- `dists/stable/Release` → `Architectures: amd64 arm64`
- `binary-arm64/Packages` → `google-chrome-stable` present, **same version as amd64** (`151.0.7922.137-1` at time of writing)

So Chrome can now be mirrored/installed on **arm64 desktop images**, not just amd64.

## Change

```diff
-ARCH=amd64
+ARCH=amd64:arm64
```

(Chrome ships only amd64 + arm64 on Linux — no armhf/riscv64 — so those two are the complete set.) Everything else (repo URL, `google-chrome-stable` package, version glob `>= 124.0`, `desktop` target, aptly method, `BS` repository) is unchanged.