### PR TITLE
webindex: pull nightly images from armbian/ci (armbian/os retired)

### DIFF
--- a/.github/workflows/webindex-update.yml
+++ b/.github/workflows/webindex-update.yml
@@ -134,9 +134,23 @@ jobs:
 
           # prepare feeds
           #A=$(rsync -ar rsync://rsync.armbian.com/dl/ | awk '{ print ""$2"|https://dl.armbian.com/"$5"|"$3"T"$4"Z" }' | grep "archive/" | grep -v ".txt")
+
+          # Nightly (rolling) images now live in armbian/ci - armbian/os is retired.
+          # That repo also stores clean X.Y.Z stable version markers (which carry no
+          # image assets), and its GitHub "latest" may or may not be a trunk build,
+          # so neither `gh release view` (no tag) nor a blind newest-release pick is
+          # safe - both can land on a 0-asset stable marker and empty the feed.
+          # Resolve the highest X.Y.Z-trunk.N tag that is promoted (not a pre-release)
+          # and actually carries assets, then read that release explicitly.
+          CI_NIGHTLY_TAG=$(gh api --paginate repos/armbian/ci/releases --jq '
+            [ .[] | select((.tag_name|test("-trunk[.]")) and (.prerelease==false) and (.assets|length>0)) ]
+            | max_by(.tag_name | capture("-trunk[.](?<n>[0-9]+)").n | tonumber) | .tag_name')
+          echo "latest nightly (armbian/ci): ${CI_NIGHTLY_TAG:-NONE}"
+          [ -z "$CI_NIGHTLY_TAG" ] && echo "::warning::No armbian/ci -trunk.N release with assets found; nightly feed will be empty"
+
           A=$(rsync -e "ssh -p 10023 -o StrictHostKeyChecking=accept-new" -ar upload@k-space.ee.armbian.com:/storage/www/dl/ | awk '{ print ""$2"|https://dl.armbian.com/"$5"|"$3"T"$4"Z" }' | grep "archive/" | grep -v ".txt\|homeassistant\|openhab\|kali\|omv")
           B=$(gh release view --json assets --repo github.com/armbian/community | jq '.assets[] | .size, .url, .createdAt' | xargs -n3 -d'\n' | grep -v ".txt" | sed "s/\"//g" | sed -e 's| |\||g')
-          C=$(gh release view --json assets --repo github.com/armbian/os | jq '.assets[] | .size, .url, .createdAt' | xargs -n3 -d'\n' | grep -v ".txt" | sed "s/\"//g" | sed -e 's| |\||g')
+          C=$(gh release view "$CI_NIGHTLY_TAG" --json assets --repo github.com/armbian/ci | jq '.assets[] | .size, .url, .createdAt' | xargs -n3 -d'\n' | grep -v ".txt" | sed "s/\"//g" | sed -e 's| |\||g')
           D=$(gh release view --json assets --repo github.com/armbian/distribution | jq '.assets[] | .size, .url, .createdAt' | xargs -n3 -d'\n' | grep -v ".txt" | sed "s/\"//g" | sed -e 's| |\||g')
 
           # debug
@@ -168,13 +182,15 @@ jobs:
               # Clean out application from extension
               FILE_EXTENSION=$(echo $FILE_EXTENSION | sed 's/.*-'$IMAGE_EXTENSION'//g'  | sed -e 's/^\.//g')
 
+              # armbian/{ci,community}/... -> "ci" / "community"; nightlies come
+              # from ci now (was "os"). f5 is the org-repo segment of the asset URL.
               IMAGE_TYPE=$(echo $IMAGE_URL | cut -d"/" -f5)
               IMAGE_CREATED=$(echo $line | cut -d"|" -f3 | sed "s/\//-/g")
               EXPOSED=false
 
               # Assemble redirector link
               PREFIX=""
-              [[ "${IMAGE_TYPE}" == "os" ]] && PREFIX="nightly/"
+              [[ "${IMAGE_TYPE}" == "ci" ]] && PREFIX="nightly/"
               REDI_EXT=$(echo $FILE_EXTENSION | rev | cut -d"." -f1 | rev | sed "s/xz//g")
               REDI_URL="https://dl.armbian.com/${PREFIX}${BOARD,,}/${IMAGE_RELEASE^}_${KERNEL_BRANCH}${IMAGE_TARGET:+_$IMAGE_TARGET}${IMAGE_EXTENSION:+-$IMAGE_EXTENSION}${REDI_EXT:+.$REDI_EXT}"
 


### PR DESCRIPTION
### Problem

The canonical **`armbian-images.json`** (built by `webindex-update.yml`)
sourced its **nightly** feed from `armbian/os`:

```bash
C=$(gh release view --json assets --repo github.com/armbian/os | jq ...)
```

Two things are broken:

1. **`armbian/os` is retired** — its newest release is `26.8.0-trunk.420`
   (July 17). So the index has been advertising month-old nightlies.
2. **`gh release view` (no tag) returns GitHub's "latest"**, which *ignores
   pre-releases* — and nightlies are published as pre-releases — so even on a
   live repo it pins an older, promoted build.

Nightlies now live in **`armbian/ci`** (`26.11.0-trunk.19`, real image
assets). But — as flagged — that repo **also stores clean `X.Y.Z` stable
version markers** (which carry **no** image assets) next to the
`X.Y.Z-trunk.N` nightlies, and its "latest" **may or may not** be a trunk
build. A naive "newest release" pick lands on a 0-asset stable marker and
**empties the nightly feed** (`gh release view --repo armbian/ci` today →
`26.8.3`, 0 assets).

### Fix

Resolve the **highest `-trunk.N` tag that is promoted (not a pre-release)
and actually carries assets**, then read that release explicitly:

```bash
CI_NIGHTLY_TAG=$(gh api --paginate repos/armbian/ci/releases --jq '
  [ .[] | select((.tag_name|test("-trunk[.]")) and (.prerelease==false) and (.assets|length>0)) ]
  | max_by(.tag_name | capture("-trunk[.](?<n>[0-9]+)").n | tonumber) | .tag_name')
C=$(gh release view "$CI_NIGHTLY_TAG" --json assets --repo github.com/armbian/ci | jq ...)
```

Also flip the nightly redirector-prefix check from `IMAGE_TYPE == "os"` to
`== "ci"` (the org/repo segment of the asset URL), so nightly `REDI_URL`s
keep their `dl.armbian.com/nightly/` prefix.

### Verified

- Selector picks **`26.11.0-trunk.19`**, skipping the `26.8.x` stable markers
  and the in-flight `trunk.20` pre-release.
- A sample ci asset parses correctly: `BOARD=Gateway-gz80x`,
  `VERSION=26.11.0-trunk.19`, `RELEASE=forky`, `KERNEL=current`,
  `IMAGE_TYPE=ci` → `PREFIX=nightly/`,
  `REDI_URL=.../nightly/gateway-gz80x/Forky_current_minimal`.
- YAML parses. A `::warning::` fires (feed empty) if no trunk-with-assets is found.

### For review

- Only the **os → ci** nightly feed is changed. `community` (B) and
  `distribution` (D) feeds are untouched — but `community` uses the same
  `gh release view` pattern and could hit the identical stable-marker trap if
  it ever stores a stable tag; happy to harden it the same way if wanted.
- ci's latest promoted nightly currently carries ~78 assets vs the old os
  release's ~200 — worth a sanity check that ci covers the intended board set.